### PR TITLE
Fixed #8: registry_test now uses the NewPID function to construct a v…

### DIFF
--- a/actor/registry_test.go
+++ b/actor/registry_test.go
@@ -8,16 +8,22 @@ import (
 )
 
 func TestGetByName(t *testing.T) {
-	PIDSeparator = "/"
+	restorePIDSeparator := PIDSeparator
+	PIDSeparator = "."
+
 	e := NewEngine()
 	e.SpawnFunc(func(c *Context) {}, "foo") // local/foo
 	time.Sleep(time.Millisecond * 10)
 	proc := e.Registry.getByID("foo")
-	require.Equal(t, "local/foo", proc.PID().String())
+	expectedPID := NewPID(LocalLookupAddr, "foo")
+	require.Equal(t, expectedPID.String(), proc.PID().String())
 
 	// local/foo/bar/q/1
 	e.SpawnFunc(func(c *Context) {}, "foo", WithTags("bar", "q", "1"))
 	time.Sleep(time.Millisecond * 10)
-	proc = e.Registry.getByID("foo/bar/q/1")
-	require.Equal(t, "local/foo/bar/q/1", proc.PID().String())
+	proc = e.Registry.getByID("foo.bar.q.1")
+	expectedPID = NewPID(LocalLookupAddr, "foo", "bar", "q", "1")
+	require.Equal(t, expectedPID.String(), proc.PID().String())
+
+	PIDSeparator = restorePIDSeparator
 }


### PR DESCRIPTION
…alid PID using the local addr and PIDSeparator.

The PIDSeparator shinangins in the test could be removed. I only added it to double check.