### PR TITLE
fixed context.GetPID methd for names without tags.

### DIFF
--- a/actor/context.go
+++ b/actor/context.go
@@ -92,7 +92,9 @@ func (c *Context) Forward(pid *PID) {
 // GetPID returns the PID of the process found by the given name and tags.
 // Returns nil when it could not find any process..
 func (c *Context) GetPID(name string, tags ...string) *PID {
-	name = name + pidSeparator + strings.Join(tags, pidSeparator)
+	if len(tags) > 0 {
+		name = name + pidSeparator + strings.Join(tags, pidSeparator)
+	}
 	proc := c.engine.Registry.getByID(name)
 	if proc != nil {
 		return proc.PID()

--- a/actor/registry_test.go
+++ b/actor/registry_test.go
@@ -27,3 +27,22 @@ func TestGetByName(t *testing.T) {
 
 	pidSeparator = restorepidSeparator
 }
+
+func TestGetByNameFromContext(t *testing.T) {
+	const PidName = "ReceiverFunc"
+
+	e := NewEngine()
+
+	// Receiver staless actor with given name:
+	e.SpawnFunc(func(c *Context) {}, PidName)
+	time.Sleep(10 * time.Millisecond)
+
+	// Transmitter stateless actor which want to lookup receiver by his name:
+	e.SpawnFunc(func(c *Context) {
+		pid := c.GetPID(PidName)
+		require.NotNil(t, pid)
+
+		expectedPID := NewPID(LocalLookupAddr, PidName)
+		require.Equal(t, expectedPID.String(), pid.String())
+	}, "TransmitterFunc")
+}


### PR DESCRIPTION
When I played with Your framework I discover that I cant find actors without tags by method context.GetPID.
I think that I found little mistake in your code and fixed that.
I write test for my case.