### PR TITLE
Fixed CPU usage caused by polling inboxes

### DIFF
--- a/actor/inbox.go
+++ b/actor/inbox.go
@@ -53,5 +53,6 @@ func (in *Inbox) Stop() error {
 }
 
 func (in *Inbox) Send(msg Envelope) {
+	in.ggq.Awake()
 	in.ggq.Write(msg)
 }

--- a/ggq/ggq_test.go
+++ b/ggq/ggq_test.go
@@ -1,24 +1,24 @@
 package ggq
 
 import (
+	"fmt"
 	"testing"
 )
 
 type consumer[T any] struct{}
 
 func (c *consumer[T]) Consume(t []T) {
-	// fmt.Println(len(t))
+	fmt.Println(t)
 }
 
 func TestSingleMessageNotConsuming(t *testing.T) {
 	q := New[int](1024, &consumer[int]{})
 
-	go func() {
-		for i := 0; i < 1; i++ {
-			q.Write(i)
-		}
-		q.Close()
-	}()
+	q.cond.Signal()
+	for i := 0; i < 10; i++ {
+		q.Write(i)
+	}
+	q.Close()
 
 	q.ReadN()
 }


### PR DESCRIPTION
Problem:
Currently the inbox queue was polling all the time for new messages. Hence, this caused a lot of CPU cycles.

Fixed:
Awake the queue when we send to inbox.