### PR TITLE
FIX: stop inbox when process is shutdown / recover panic on start

### DIFF
--- a/actor/inbox.go
+++ b/actor/inbox.go
@@ -72,10 +72,7 @@ func (in *Inbox) process() {
 
 func (in *Inbox) run() {
 	i, t := 0, in.scheduler.Throughput()
-	for {
-		if in.procStatus == stopped {
-			return
-		}
+	for in.procStatus != stopped {
 		if i > t {
 			i = 0
 			runtime.Gosched()

--- a/actor/inbox.go
+++ b/actor/inbox.go
@@ -12,6 +12,7 @@ const defaultThroughput = 300
 const (
 	idle int32 = iota
 	running
+	stopped
 )
 
 type Scheduler interface {
@@ -72,6 +73,9 @@ func (in *Inbox) process() {
 func (in *Inbox) run() {
 	i, t := 0, in.scheduler.Throughput()
 	for {
+		if in.procStatus == stopped {
+			return
+		}
 		if i > t {
 			i = 0
 			runtime.Gosched()
@@ -91,5 +95,6 @@ func (in *Inbox) Start(proc Processer) {
 }
 
 func (in *Inbox) Stop() error {
+	in.procStatus = stopped
 	return nil
 }

--- a/actor/process.go
+++ b/actor/process.go
@@ -118,7 +118,6 @@ func (p *process) Start() {
 }
 
 func (p *process) tryRestart(v any) {
-	p.restarts++
 	// InternalError does not take the maximum restarts into account.
 	// For now, InternalError is getting triggered when we are dialing
 	// a remote node. By doing this, we can keep dialing until it comes
@@ -144,6 +143,8 @@ func (p *process) tryRestart(v any) {
 		p.cleanup(nil)
 		return
 	}
+
+	p.restarts++
 	// Restart the process after its restartDelay
 	log.Errorw("[PROCESS] actor restarting", log.M{
 		"n":           p.restarts,


### PR DESCRIPTION
When the process was shutdown, the processer was still invoked by inbox.
Also, if the MaxRestarts was 3 for example, the process would restart 3 times, trigger shutdown, restart 5th time, 6th time, 7th time and so on, depending on number of messages.