### PR TITLE
replace logrus with log/slog from stdlib

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
 
       - name: Build
         run: go build -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ bin
 TODO.txt
 TODO
 _test
-.vscode
+/.vscode
+/.idea

--- a/README.md
+++ b/README.md
@@ -3,17 +3,25 @@
 
 # Blazingly fast, low latency actors for Golang
 
-Hollywood is an ULTRA fast actor engine build for speed and low-latency applications. Think about game servers, advertising brokers, trading engines, etc... It can handle **10 million messages in under 1 second**.
+Hollywood is an ULTRA fast actor engine build for speed and low-latency applications. Think about game servers,
+advertising brokers, trading engines, etc... It can handle **10 million messages in under 1 second**.
 
 ## What is the actor model?
 
-The Actor Model is a computational model used to build highly concurrent and distributed systems. It was introduced by Carl Hewitt in 1973 as a way to handle complex systems in a more scalable and fault-tolerant manner.
+The Actor Model is a computational model used to build highly concurrent and distributed systems. It was introduced by
+Carl Hewitt in 1973 as a way to handle complex systems in a more scalable and fault-tolerant manner.
 
-In the Actor Model, the basic building block is an actor, called receiver in Hollywood, which is an independent unit of computation that communicates with other actors by exchanging messages. Each actor has its own state and behavior, and can only communicate with other actors by sending messages. This message-passing paradigm allows for a highly decentralized and fault-tolerant system, as actors can continue to operate independently even if other actors fail or become unavailable.
+In the Actor Model, the basic building block is an actor, called receiver in Hollywood, which is an independent unit of
+computation that communicates with other actors by exchanging messages. Each actor has its own state and behavior, and
+can only communicate with other actors by sending messages. This message-passing paradigm allows for a highly
+decentralized and fault-tolerant system, as actors can continue to operate independently even if other actors fail or
+become unavailable.
 
-Actors can be organized into hierarchies, with higher-level actors supervising and coordinating lower-level actors. This allows for the creation of complex systems that can handle failures and errors in a graceful and predictable way.
+Actors can be organized into hierarchies, with higher-level actors supervising and coordinating lower-level actors. This
+allows for the creation of complex systems that can handle failures and errors in a graceful and predictable way.
 
-By using the Actor Model in your application, you can build highly scalable and fault-tolerant systems that can handle a large number of concurrent users and complex interactions.
+By using the Actor Model in your application, you can build highly scalable and fault-tolerant systems that can handle a
+large number of concurrent users and complex interactions.
 
 ## Features
 
@@ -44,9 +52,10 @@ go get github.com/anthdm/hollywood/...
 
 # Quickstart
 
-> The **[examples](https://github.com/anthdm/hollywood/tree/master/examples)** folder is the best place to learn and explore Hollywood.
+> The **[examples](https://github.com/anthdm/hollywood/tree/master/examples)** folder is the best place to learn and
+> explore Hollywood.
 
-```Go
+```go
 type message struct {
 	data string
 }
@@ -78,8 +87,8 @@ func main() {
 
 ## Spawning receivers with configuration
 
-```Go
-e.Spawn(newFoo, "foo",
+```go
+    e.Spawn(newFoo, "foo",
 	actor.WithMaxRestarts(4),
 	actor.WithInboxSize(1024 * 2),
 	actor.WithTags("bar", "1"),
@@ -125,43 +134,81 @@ time.Sleep(time.Second)
 
 ## Customizing the Engine
 
-```Go
-cfg := actor.Config{
+```go
+    cfg := actor.Config{
 	PIDSeparator: "->",
-}
-e := actor.NewEngine(cfg)
+    }
+    e := actor.NewEngine(cfg)
 ```
 
 After configuring the Engine with a custom PID Separator the string representation of PIDS will look like this:
 
-```Go
-pid := actor.NewPID("127.0.0.1:3000", "foo", "bar", "baz", "1")
-// 127.0.0.1:3000->foo->bar->baz->1
+```go
+    pid := actor.NewPID("127.0.0.1:3000", "foo", "bar", "baz", "1")
+    // 127.0.0.1:3000->foo->bar->baz->1
 ```
+
+Note that you can also provide a custom logger to the engine. See the Logging section for more details.
 
 ## Custom middleware
 
-You can add custom middleware to your Receivers. This can be usefull for storing metrics, saving and loading data for your Receivers on `actor.Started` and `actor.Stopped`.
+You can add custom middleware to your Receivers. This can be usefull for storing metrics, saving and loading data for
+your Receivers on `actor.Started` and `actor.Stopped`.
 
-For examples on how to implement custom middleware, check out the middleware folder in the **[examples](https://github.com/anthdm/hollywood/tree/master/examples/middleware)**
+For examples on how to implement custom middleware, check out the middleware folder in the *
+*[examples](https://github.com/anthdm/hollywood/tree/master/examples/middleware)**
 
 ## Logging
 
-You can set the log level of Hollywoods log module:
+The default for Hollywood is, as any good library, not to log anything, but rather to rely on the application to
+configure logging as it sees fit. However, as a convenience, Hollywood provides a simple logging package that
+you can use to gain some insight into what is going on inside the library.
 
-```Go
-import "github.com/anthdm/hollywood/log
+When you create a Hollywood engine, you can provide an optional actor configuration. This gives you the opportunity to
+have the log package create a suitable logger. The logger will be based on the standard library's `log/slog` package.
 
-log.SetLevel(log.LevelInfo)
+If you want Hollywood to log with its defaults, it will provide structured logging with the loglevel being `ÌNFO`.
+You'll then initialize the engine as such:
+
+```go
+    engine := actor.NewEngine(actor.Config{Logger: log.Default()})
 ```
 
-To disable all logging
+If you want more control, say by having having the loglevel be DEBUG and the output format be JSON, you can do so by
 
-```Go
-import "github.com/anthdm/hollywood/log
-
-log.SetLevel(log.LevelPanic)
+```go
+    lh := log.NewHandler(os.Stdout, log.JsonFormat, slog.LevelDebug)
+    engine := actor.NewEngine(actor.Config{Logger: log.NewLogger("[engine]", lh)})
 ```
+
+This will have the engine itself log with the field "log", prepopulated with the value "[engine]" for the engine itself.
+The various subsystems will change the log field to reflect their own name.
+
+### Log levels
+
+The log levels are, in order of severity:
+
+* `slog.LevelDebug`
+* `slog.LevelInfo`
+* `slog.LevelWarn`
+* `slog.LevelError`
+
+### Log components.
+
+The log field "log" will be populated with the name of the subsystem that is logging. The subsystems are:
+
+* `[engine]`
+* `[context`
+* `[deadLetter]`
+* `[eventStream]`
+* `[registry]`
+* `[stream_reader]`
+* `[stream_writer]`
+* `[stream_router]`
+
+In addition, the logger will log with log=$ACTOR_NAME for any actor that has a name.
+
+See the log package for more details about the implementation.
 
 # Test
 

--- a/_bench/main.go
+++ b/_bench/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
 	"runtime"
 	"time"
 
 	"github.com/anthdm/hollywood/actor"
-	"github.com/anthdm/hollywood/log"
 	"github.com/anthdm/hollywood/remote"
 )
 
@@ -55,9 +56,9 @@ func benchmarkLocal() {
 
 func main() {
 	if runtime.GOMAXPROCS(runtime.NumCPU()) == 1 {
-		log.Fatalw("Please use a system with more than 1 CPU. Its 2023...", nil)
+		slog.Error("GOMAXPROCS must be greater than 1")
+		os.Exit(1)
 	}
-	log.SetLevel(log.LevelPanic)
 	benchmarkLocal()
 	benchmarkRemote()
 }

--- a/actor/context.go
+++ b/actor/context.go
@@ -19,6 +19,7 @@ type Context struct {
 	// when the child dies.
 	parentCtx *Context
 	children  *safemap.SafeMap[string, *PID]
+	logger    log.Logger
 }
 
 func newContext(e *Engine, pid *PID) *Context {
@@ -43,9 +44,7 @@ func (c *Context) Request(pid *PID, msg any, timeout time.Duration) *Response {
 // Respond will sent the given message to the sender of the current received message.
 func (c *Context) Respond(msg any) {
 	if c.sender == nil {
-		log.Warnw("[RESPOND] context got no sender", log.M{
-			"pid": c.PID(),
-		})
+		c.logger.Warnw("context got no sender", "func", "Respond", "pid", c.PID())
 		return
 	}
 	c.engine.Send(c.sender, msg)

--- a/actor/context.go
+++ b/actor/context.go
@@ -27,6 +27,7 @@ func newContext(e *Engine, pid *PID) *Context {
 		engine:   e,
 		pid:      pid,
 		children: safemap.New[string, *PID](),
+		logger:   e.logger.SubLogger("[context]"),
 	}
 }
 

--- a/actor/deadletter.go
+++ b/actor/deadletter.go
@@ -20,6 +20,7 @@ func newDeadLetter(eventStream *EventStream) *deadLetter {
 	return &deadLetter{
 		eventStream: eventStream,
 		pid:         NewPID(LocalLookupAddr, "deadLetter"),
+		logger:      eventStream.logger.SubLogger("[deadLetter]"),
 	}
 }
 

--- a/actor/deadletter.go
+++ b/actor/deadletter.go
@@ -13,6 +13,7 @@ import (
 type deadLetter struct {
 	eventStream *EventStream
 	pid         *PID
+	logger      log.Logger
 }
 
 func newDeadLetter(eventStream *EventStream) *deadLetter {
@@ -23,11 +24,11 @@ func newDeadLetter(eventStream *EventStream) *deadLetter {
 }
 
 func (d *deadLetter) Send(dest *PID, msg any, sender *PID) {
-	log.Warnw("[DEADLETTER]", log.M{
-		"dest":   dest,
-		"msg":    reflect.TypeOf(msg),
-		"sender": sender,
-	})
+	d.logger.Warnw("Send",
+		"dest", dest,
+		"msg", reflect.TypeOf(msg),
+		"sender", sender,
+	)
 	d.eventStream.Publish(&DeadLetterEvent{
 		Target:  dest,
 		Message: msg,

--- a/actor/engine.go
+++ b/actor/engine.go
@@ -94,7 +94,7 @@ func (e *Engine) SpawnFunc(f func(*Context), id string, opts ...OptFunc) *PID {
 	return e.Spawn(newFuncReceiver(f), id, opts...)
 }
 
-// SpawnProc spawns the give Processer. This function is usefull when working
+// SpawnProc spawns the give Processer. This function is useful when working
 // with custom created Processes. Take a look at the streamWriter as an example.
 func (e *Engine) SpawnProc(p Processer) *PID {
 	e.Registry.add(p)

--- a/actor/engine.go
+++ b/actor/engine.go
@@ -61,6 +61,7 @@ func (e *Engine) configure(cfg Config) {
 	if cfg.PIDSeparator != "" {
 		pidSeparator = cfg.PIDSeparator
 	}
+	e.logger = cfg.Logger
 }
 
 // WithRemote returns a new actor Engine with the given Remoter,
@@ -69,13 +70,6 @@ func (e *Engine) WithRemote(r Remoter) {
 	e.remote = r
 	e.address = r.Address()
 	r.Start()
-}
-
-// WithLogger returns a new actor Engine with the given Logger
-func (e *Engine) WithLogger(l log.Logger) *Engine {
-	e.logger = l
-	e.EventStream.attachLogger(l.SubLogger("[eventStream]"))
-	return e
 }
 
 // Spawn spawns a process that will producer by the given Producer and

--- a/actor/engine.go
+++ b/actor/engine.go
@@ -44,13 +44,12 @@ type Engine struct {
 
 // NewEngine returns a new actor Engine.
 func NewEngine(cfg ...Config) *Engine {
-	e := &Engine{
-		EventStream: NewEventStream(),
-		address:     LocalLookupAddr,
-	}
+	e := &Engine{}
 	if len(cfg) == 1 {
 		e.configure(cfg[0])
 	}
+	e.EventStream = NewEventStream(e.logger)
+	e.address = LocalLookupAddr
 	e.Registry = newRegistry(e)
 	e.deadLetter = newDeadLetter(e.EventStream)
 	e.Registry.add(e.deadLetter)

--- a/actor/engine.go
+++ b/actor/engine.go
@@ -74,6 +74,7 @@ func (e *Engine) WithRemote(r Remoter) {
 // WithLogger returns a new actor Engine with the given Logger
 func (e *Engine) WithLogger(l log.Logger) *Engine {
 	e.logger = l
+	e.EventStream.attachLogger(l.SubLogger("[eventStream]"))
 	return e
 }
 

--- a/actor/event_stream.go
+++ b/actor/event_stream.go
@@ -68,3 +68,7 @@ func (e *EventStream) Len() int {
 	defer e.mu.RUnlock()
 	return len(e.subs)
 }
+
+func (e *EventStream) attachLogger(l log.Logger) {
+	e.logger = l
+}

--- a/actor/event_stream.go
+++ b/actor/event_stream.go
@@ -15,8 +15,9 @@ type EventSub struct {
 type EventStreamFunc func(event any)
 
 type EventStream struct {
-	mu   sync.RWMutex
-	subs map[*EventSub]EventStreamFunc
+	mu     sync.RWMutex
+	subs   map[*EventSub]EventStreamFunc
+	logger log.Logger
 }
 
 func NewEventStream() *EventStream {
@@ -31,10 +32,10 @@ func (e *EventStream) Unsubscribe(sub *EventSub) {
 
 	delete(e.subs, sub)
 
-	log.Tracew("[EVENTSTREAM] unsubscribe", log.M{
-		"subs": len(e.subs),
-		"id":   sub.id,
-	})
+	e.logger.Debugw("unsubscribe",
+		"subs", len(e.subs),
+		"id", sub.id,
+	)
 }
 
 func (e *EventStream) Subscribe(f EventStreamFunc) *EventSub {
@@ -46,10 +47,10 @@ func (e *EventStream) Subscribe(f EventStreamFunc) *EventSub {
 	}
 	e.subs[sub] = f
 
-	log.Tracew("[EVENTSTREAM] subscribe", log.M{
-		"subs": len(e.subs),
-		"id":   sub.id,
-	})
+	e.logger.Debugw("subscribe",
+		"subs", len(e.subs),
+		"id", sub.id,
+	)
 
 	return sub
 }

--- a/actor/event_stream.go
+++ b/actor/event_stream.go
@@ -69,7 +69,3 @@ func (e *EventStream) Len() int {
 	defer e.mu.RUnlock()
 	return len(e.subs)
 }
-
-func (e *EventStream) attachLogger(l log.Logger) {
-	e.logger = l
-}

--- a/actor/event_stream.go
+++ b/actor/event_stream.go
@@ -20,9 +20,10 @@ type EventStream struct {
 	logger log.Logger
 }
 
-func NewEventStream() *EventStream {
+func NewEventStream(l log.Logger) *EventStream {
 	return &EventStream{
-		subs: make(map[*EventSub]EventStreamFunc),
+		subs:   make(map[*EventSub]EventStreamFunc),
+		logger: l.SubLogger("[eventStream]"),
 	}
 }
 

--- a/actor/process.go
+++ b/actor/process.go
@@ -44,6 +44,7 @@ func newProcess(e *Engine, opts Opts) *process {
 		Opts:    opts,
 		context: ctx,
 		mbuffer: nil,
+		logger:  e.logger.SubLogger(opts.Name),
 	}
 	p.inbox.Start(p)
 	return p

--- a/actor/process.go
+++ b/actor/process.go
@@ -32,6 +32,7 @@ type process struct {
 	restarts int32
 
 	mbuffer []Envelope
+	logger  log.Logger
 }
 
 func newProcess(e *Engine, opts Opts) *process {
@@ -110,11 +111,7 @@ func (p *process) Start() {
 	p.context.message = Started{}
 	applyMiddleware(recv.Receive, p.Opts.Middleware...)(p.context)
 	p.context.engine.EventStream.Publish(&ActivationEvent{PID: p.pid})
-
-	log.Tracew("[PROCESS] started", log.M{
-		"pid": p.pid,
-	})
-
+	p.logger.Debugw("started", "pid", p.pid)
 	// If we have messages in our buffer, invoke them.
 	if len(p.mbuffer) > 0 {
 		p.Invoke(p.mbuffer)
@@ -129,9 +126,7 @@ func (p *process) tryRestart(v any) {
 	// back up. NOTE: not sure if that is the best option. What if that
 	// node never comes back up again?
 	if msg, ok := v.(*InternalError); ok {
-		log.Errorw(msg.From, log.M{
-			"error": msg.Err,
-		})
+		p.logger.Errorw(msg.From, "err", msg.Err)
 		time.Sleep(p.Opts.RestartDelay)
 		p.Start()
 		return
@@ -141,22 +136,20 @@ func (p *process) tryRestart(v any) {
 	// If we reach the max restarts, we shutdown the inbox and clean
 	// everything up.
 	if p.restarts == p.MaxRestarts {
-		log.Errorw("[PROCESS] max restarts exceeded, shutting down...", log.M{
-			"pid":      p.pid,
-			"restarts": p.restarts,
-		})
+		p.logger.Errorw("max restarts exceeded, shutting down...",
+			"pid", p.pid, "restarts", p.restarts)
 		p.cleanup(nil)
 		return
 	}
 
 	p.restarts++
 	// Restart the process after its restartDelay
-	log.Errorw("[PROCESS] actor restarting", log.M{
-		"n":           p.restarts,
-		"maxRestarts": p.MaxRestarts,
-		"pid":         p.pid,
-		"reason":      v,
-	})
+	p.logger.Errorw("actor restarting",
+		"n", p.restarts,
+		"maxRestarts", p.MaxRestarts,
+		"pid", p.pid,
+		"reason", v,
+	)
 	time.Sleep(p.Opts.RestartDelay)
 	p.Start()
 }
@@ -185,9 +178,7 @@ func (p *process) cleanup(wg *sync.WaitGroup) {
 			proc.Shutdown(wg)
 		}
 	}
-	log.Tracew("[PROCESS] shutdown", log.M{
-		"pid": p.pid,
-	})
+	p.logger.Debugw("shutdown", "pid", p.pid)
 	// Send TerminationEvent to the eventstream
 	p.context.engine.EventStream.Publish(&TerminationEvent{PID: p.pid})
 	if wg != nil {

--- a/actor/registry.go
+++ b/actor/registry.go
@@ -19,6 +19,7 @@ func newRegistry(e *Engine) *Registry {
 	return &Registry{
 		lookup: make(map[string]Processer, 1024),
 		engine: e,
+		logger: e.logger.SubLogger("[registry]"),
 	}
 }
 

--- a/actor/registry.go
+++ b/actor/registry.go
@@ -12,6 +12,7 @@ type Registry struct {
 	mu     sync.RWMutex
 	lookup map[string]Processer
 	engine *Engine
+	logger log.Logger
 }
 
 func newRegistry(e *Engine) *Registry {
@@ -50,9 +51,9 @@ func (r *Registry) add(proc Processer) {
 	defer r.mu.Unlock()
 	id := proc.PID().ID
 	if _, ok := r.lookup[id]; ok {
-		log.Warnw("[REGISTRY] process already registered", log.M{
-			"pid": proc.PID(),
-		})
+		r.logger.Warnw("process already registered",
+			"pid", proc.PID(),
+		)
 		return
 	}
 	r.lookup[id] = proc

--- a/examples/chat/client/main.go
+++ b/examples/chat/client/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"github.com/anthdm/hollywood/log"
 	"log/slog"
 	"os"
 
@@ -46,10 +47,10 @@ func main() {
 	)
 	flag.Parse()
 
-	e := actor.NewEngine()
+	e := actor.NewEngine().WithLogger(log.Default())
 	rem := remote.New(e, remote.Config{
 		ListenAddr: *listenAt,
-	})
+	}).WithLogger(log.NewLogger("[remote]", log.NewHandler(os.Stdout, log.TextFormat, slog.LevelDebug)))
 	e.WithRemote(rem)
 
 	var (

--- a/examples/chat/client/main.go
+++ b/examples/chat/client/main.go
@@ -4,11 +4,11 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/anthdm/hollywood/actor"
 	"github.com/anthdm/hollywood/examples/chat/types"
-	"github.com/anthdm/hollywood/log"
 	"github.com/anthdm/hollywood/remote"
 )
 
@@ -69,7 +69,7 @@ func main() {
 		e.SendWithSender(serverPID, msg, clientPID)
 	}
 	if err := scanner.Err(); err != nil {
-		log.Errorw("failed to read message from stdin", log.M{"err": err})
+		slog.Error("failed to read message from stdin", "err", err)
 	}
 
 	// When breaked out of the loop on error let the server know

--- a/examples/chat/client/main.go
+++ b/examples/chat/client/main.go
@@ -47,10 +47,11 @@ func main() {
 	)
 	flag.Parse()
 
-	e := actor.NewEngine().WithLogger(log.Default())
+	e := actor.NewEngine(actor.Config{Logger: log.Default()})
 	rem := remote.New(e, remote.Config{
 		ListenAddr: *listenAt,
-	}).WithLogger(log.NewLogger("[remote]", log.NewHandler(os.Stdout, log.TextFormat, slog.LevelDebug)))
+		Logger:     log.NewLogger("[remote]", log.NewHandler(os.Stdout, log.TextFormat, slog.LevelDebug)),
+	})
 	e.WithRemote(rem)
 
 	var (

--- a/examples/chat/server/main.go
+++ b/examples/chat/server/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"flag"
+	"log/slog"
 
 	"github.com/anthdm/hollywood/actor"
 	"github.com/anthdm/hollywood/examples/chat/types"
-	"github.com/anthdm/hollywood/log"
 	"github.com/anthdm/hollywood/remote"
 )
 
@@ -30,16 +30,15 @@ func (s *server) Receive(ctx *actor.Context) {
 			return
 		}
 		delete(s.clients, ctx.Sender())
-		log.Infow("client disconnected", log.M{
-			"pid":      ctx.Sender(),
-			"username": username,
-		})
+		slog.Info("client disconnected",
+			"pid", ctx.Sender(),
+			"username", username)
 	case *types.Connect:
 		s.clients[ctx.Sender()] = msg.Username
-		log.Infow("new client connected", log.M{
-			"pid":      ctx.Sender(),
-			"username": msg.Username,
-		})
+		slog.Info("new client connected",
+			"pid", ctx.Sender(),
+			"username", msg.Username,
+		)
 	}
 }
 
@@ -58,7 +57,6 @@ func main() {
 		listenAt = flag.String("listen", "127.0.0.1:4000", "")
 	)
 	flag.Parse()
-	log.SetLevel(log.LevelInfo)
 	e := actor.NewEngine()
 	rem := remote.New(e, remote.Config{
 		ListenAddr: *listenAt,

--- a/examples/eventstream/main.go
+++ b/examples/eventstream/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	lh := log.NewHandler(os.Stdout, log.TextFormat, slog.LevelDebug)
-	e := actor.NewEngine().WithLogger(log.NewLogger("[engine]", lh))
+	e := actor.NewEngine(actor.Config{Logger: log.NewLogger("[engine]", lh)})
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 

--- a/examples/eventstream/main.go
+++ b/examples/eventstream/main.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"fmt"
+	"github.com/anthdm/hollywood/log"
+	"log/slog"
+	"os"
 	"sync"
 
 	"github.com/anthdm/hollywood/actor"
 )
 
 func main() {
-	e := actor.NewEngine()
+	lh := log.NewHandler(os.Stdout, log.TextFormat, slog.LevelDebug)
+	e := actor.NewEngine().WithLogger(log.NewLogger("[engine]", lh))
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 

--- a/examples/helloworld/main.go
+++ b/examples/helloworld/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"github.com/anthdm/hollywood/log"
+	"log/slog"
+	"os"
 
 	"github.com/anthdm/hollywood/actor"
 )
@@ -28,7 +31,8 @@ func (f *foo) Receive(ctx *actor.Context) {
 }
 
 func main() {
-	engine := actor.NewEngine()
+	lh := log.NewHandler(os.Stdout, log.JsonFormat, slog.LevelDebug)
+	engine := actor.NewEngine(actor.Config{Logger: log.NewLogger("[engine]", lh)})
 	pid := engine.Spawn(newFoo, "my_actor")
 	for i := 0; i < 100; i++ {
 		engine.Send(pid, &message{data: "hello world!"})

--- a/examples/tcpserver/main.go
+++ b/examples/tcpserver/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"os/signal"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	"github.com/anthdm/hollywood/actor"
-	"github.com/anthdm/hollywood/log"
 )
 
 type handler struct{}
@@ -49,7 +49,7 @@ func (s *session) Receive(c *actor.Context) {
 	switch c.Message().(type) {
 	case actor.Initialized:
 	case actor.Started:
-		log.Infow("new connection", log.M{"addr": s.conn.RemoteAddr()})
+		slog.Info("new connection", "addr", s.conn.RemoteAddr())
 		go s.readLoop(c)
 	case actor.Stopped:
 		s.conn.Close()
@@ -61,7 +61,7 @@ func (s *session) readLoop(c *actor.Context) {
 	for {
 		n, err := s.conn.Read(buf)
 		if err != nil {
-			log.Errorw("conn read error", log.M{"err": err})
+			slog.Error("conn read error", "err", err)
 			break
 		}
 		// copy shared buffer, to prevent race conditions.
@@ -110,16 +110,16 @@ func (s *server) Receive(c *actor.Context) {
 		// start the handler that will handle the incomming messages from clients/sessions.
 		c.SpawnChild(newHandler, "handler")
 	case actor.Started:
-		log.Infow("server started", log.M{"addr": s.listenAddr})
+		slog.Info("server started", "addr", s.listenAddr)
 		go s.acceptLoop(c)
 	case actor.Stopped:
 		// on stop all the childs sessions will automatically get the stop
 		// message and close all their underlying connection.
 	case *connAdd:
-		log.Tracew("added new connection to my map", log.M{"addr": msg.conn.RemoteAddr(), "pid": msg.pid})
+		slog.Debug("added new connection to my map", "addr", msg.conn.RemoteAddr(), "pid", msg.pid)
 		s.sessions[msg.pid] = msg.conn
 	case *connRem:
-		log.Tracew("removed connection from my map", log.M{"pid": msg.pid})
+		slog.Debug("removed connection from my map", "pid", msg.pid)
 		delete(s.sessions, msg.pid)
 	}
 }
@@ -128,7 +128,7 @@ func (s *server) acceptLoop(c *actor.Context) {
 	for {
 		conn, err := s.ln.Accept()
 		if err != nil {
-			log.Errorw("accept error", log.M{"err": err})
+			slog.Error("accept error", "err", err)
 			break
 		}
 		pid := c.SpawnChild(newSession(conn), "session", actor.WithTags(conn.RemoteAddr().String()))

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anthdm/hollywood
 
-go 1.21
+go 1.20
 
 require (
 	github.com/planetscale/vtprotobuf v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/anthdm/hollywood
 
-go 1.19
+go 1.21
 
 require (
 	github.com/planetscale/vtprotobuf v0.4.0
-	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.30.0

--- a/log/log.go
+++ b/log/log.go
@@ -6,8 +6,11 @@ import (
 	"os"
 )
 
+// Logger keeps track of the logger. The baselogger points to the original logger
+// and slogger is a reference to the current logger
 type Logger struct {
-	slogger *slog.Logger
+	slogger    *slog.Logger
+	baselogger *slog.Logger
 }
 
 type LoggerFormat uint32
@@ -20,7 +23,10 @@ const (
 // NewLogger creates a new logger with the given name and handler
 func NewLogger(name string, handler slog.Handler) Logger {
 	logger := slog.New(handler)
-	return Logger{logger.With("log", name)}
+	return Logger{
+		slogger:    logger.With("log", name),
+		baselogger: logger,
+	}
 }
 
 // SubLogger returns a new logger with the given name as a sublogger
@@ -29,7 +35,8 @@ func (l Logger) SubLogger(name string) Logger {
 		return Logger{}
 	}
 	return Logger{
-		slogger: l.slogger.With("log", name),
+		slogger:    l.baselogger.With("log", name),
+		baselogger: l.baselogger,
 	}
 }
 
@@ -43,11 +50,11 @@ func Default() Logger {
 func NewHandler(w io.Writer, format LoggerFormat, loglevel slog.Level) slog.Handler {
 	switch format {
 	case JsonFormat:
-		return slog.NewTextHandler(w, &slog.HandlerOptions{
+		return slog.NewJSONHandler(w, &slog.HandlerOptions{
 			Level: loglevel,
 		})
 	case TextFormat:
-		return slog.NewJSONHandler(w, &slog.HandlerOptions{
+		return slog.NewTextHandler(w, &slog.HandlerOptions{
 			Level: loglevel,
 		})
 	default:
@@ -59,26 +66,26 @@ func (l Logger) Infow(msg string, args ...any) {
 	if l.slogger == nil {
 		return
 	}
-	l.slogger.Info(msg, args)
+	l.slogger.Info(msg, args...)
 }
 
 func (l Logger) Debugw(msg string, args ...any) {
 	if l.slogger == nil {
 		return
 	}
-	l.slogger.Debug(msg, args)
+	l.slogger.Debug(msg, args...)
 }
 
 func (l Logger) Warnw(msg string, args ...any) {
 	if l.slogger == nil {
 		return
 	}
-	l.slogger.Warn(msg, args)
+	l.slogger.Warn(msg, args...)
 }
 
 func (l Logger) Errorw(msg string, args ...any) {
 	if l.slogger == nil {
 		return
 	}
-	l.slogger.Error(msg, args)
+	l.slogger.Error(msg, args...)
 }

--- a/log/log.go
+++ b/log/log.go
@@ -3,6 +3,7 @@ package log
 import (
 	"io"
 	"log/slog"
+	"os"
 )
 
 type Logger struct {
@@ -31,13 +32,20 @@ func NewHandler(w io.Writer, format LoggerFormat, loglevel slog.Level) slog.Hand
 	}
 }
 
-// New creates a new logger. You can specify an optional handler. If
-// no handler is given, the logger will be a no-op logger, which is the default.
+// DefaultEngineLogger returns a logger that logs to stdout with the
+// TextFormat and log level Info. This is the recommended logger to use
+// You can supply your own logger if you want to, using NewLogger and NewHandler
+func DefaultEngineLogger() Logger {
+	return NewLogger("[engine]", NewHandler(os.Stdout, TextFormat, slog.LevelInfo))
+}
+
+// NewLogger creates a new logger with the given name and handler
 func NewLogger(name string, handler slog.Handler) Logger {
 	logger := slog.New(handler)
 	return Logger{logger.With("log", name)}
 }
 
+// SubLogger returns a new logger with the given name as a sublogger
 func (l Logger) SubLogger(name string) Logger {
 	if l.slogger == nil { // no-op logger
 		return Logger{}

--- a/log/log.go
+++ b/log/log.go
@@ -17,28 +17,6 @@ const (
 	TextFormat
 )
 
-func NewHandler(w io.Writer, format LoggerFormat, loglevel slog.Level) slog.Handler {
-	switch format {
-	case JsonFormat:
-		return slog.NewTextHandler(w, &slog.HandlerOptions{
-			Level: loglevel,
-		})
-	case TextFormat:
-		return slog.NewJSONHandler(w, &slog.HandlerOptions{
-			Level: loglevel,
-		})
-	default:
-		panic("unknown format") // can't happen
-	}
-}
-
-// DefaultEngineLogger returns a logger that logs to stdout with the
-// TextFormat and log level Info. This is the recommended logger to use
-// You can supply your own logger if you want to, using NewLogger and NewHandler
-func DefaultEngineLogger() Logger {
-	return NewLogger("[engine]", NewHandler(os.Stdout, TextFormat, slog.LevelInfo))
-}
-
 // NewLogger creates a new logger with the given name and handler
 func NewLogger(name string, handler slog.Handler) Logger {
 	logger := slog.New(handler)
@@ -52,6 +30,28 @@ func (l Logger) SubLogger(name string) Logger {
 	}
 	return Logger{
 		slogger: l.slogger.With("log", name),
+	}
+}
+
+// Default returns a logger that logs to stdout with the
+// TextFormat and log level Info. This is the recommended logger to use
+// You can supply your own logger if you want to, using NewLogger and NewHandler
+func Default() Logger {
+	return NewLogger("[engine]", NewHandler(os.Stdout, TextFormat, slog.LevelInfo))
+}
+
+func NewHandler(w io.Writer, format LoggerFormat, loglevel slog.Level) slog.Handler {
+	switch format {
+	case JsonFormat:
+		return slog.NewTextHandler(w, &slog.HandlerOptions{
+			Level: loglevel,
+		})
+	case TextFormat:
+		return slog.NewJSONHandler(w, &slog.HandlerOptions{
+			Level: loglevel,
+		})
+	default:
+		panic("unknown format") // can't happen
 	}
 }
 

--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -92,7 +92,7 @@ func TestRequestResponse(t *testing.T) {
 
 func makeRemoteEngine(listenAddr string) *actor.Engine {
 	e := actor.NewEngine()
-	r := New(e, Config{listenAddr})
+	r := New(e, Config{ListenAddr: listenAddr})
 	e.WithRemote(r)
 	return e
 }


### PR DESCRIPTION
The default now is not to log anything.
So, if the application needs logging, it wouldn't do this:
```
	engine := actor.NewEngine()
```
but rather
```
	engine := actor.NewEngine(actor.Config{Logger: log.Default()})
```
for the default logging (which can be changed)
or for more control:
```
	lh := log.NewHandler(os.Stdout, log.JsonFormat, slog.LevelDebug)
	engine := actor.NewEngine(actor.Config{Logger: log.NewLogger("[engine]", lh)})
```

Since slog is so versatile this should be good enough for anybody.

No big semantic changes. I did remove the log.Fatal and log.Panic-level and replaces these with panics.
Removes uses of the log package from the examples, they shouldn't be using the library for logging, but rather log directly with log or slog.

Note that one test is failing, it was failing before as well. 

Overall, I like the package. God job.

Closes: #54

