### PR TITLE
Replace mutex-guarded map with sync.Map

### DIFF
--- a/remote/remote_test.go
+++ b/remote/remote_test.go
@@ -1,6 +1,8 @@
 package remote
 
 import (
+	"fmt"
+	"math/rand"
 	"sync"
 	"testing"
 	"time"
@@ -16,13 +18,14 @@ func init() {
 }
 
 func TestSend(t *testing.T) {
+	const msgs = 10
 	var (
-		a  = makeRemoteEngine("127.0.0.2:4000")
-		b  = makeRemoteEngine("127.0.0.2:5000")
+		a  = makeRemoteEngine(getRandomLocalhostAddr())
+		b  = makeRemoteEngine(getRandomLocalhostAddr())
 		wg = sync.WaitGroup{}
 	)
 
-	wg.Add(10) // send 2 messages
+	wg.Add(msgs) // send msgs messages
 	pid := a.SpawnFunc(func(c *actor.Context) {
 		switch msg := c.Message().(type) {
 		case *TestMessage:
@@ -31,7 +34,7 @@ func TestSend(t *testing.T) {
 		}
 	}, "dfoo")
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < msgs; i++ {
 		b.Send(pid, &TestMessage{Data: []byte("foo")})
 	}
 	wg.Wait()
@@ -39,8 +42,8 @@ func TestSend(t *testing.T) {
 
 func TestWithSender(t *testing.T) {
 	var (
-		a         = makeRemoteEngine("127.0.0.4:4000")
-		b         = makeRemoteEngine("127.0.0.4:5000")
+		a         = makeRemoteEngine(getRandomLocalhostAddr())
+		b         = makeRemoteEngine(getRandomLocalhostAddr())
 		wg        = sync.WaitGroup{}
 		senderPID = actor.NewPID("a", "b")
 	)
@@ -65,8 +68,8 @@ func TestWithSender(t *testing.T) {
 
 func TestRequestResponse(t *testing.T) {
 	var (
-		a  = makeRemoteEngine("127.0.0.1:4001")
-		b  = makeRemoteEngine("127.0.0.1:5001")
+		a  = makeRemoteEngine(getRandomLocalhostAddr())
+		b  = makeRemoteEngine(getRandomLocalhostAddr())
 		wg = sync.WaitGroup{}
 	)
 
@@ -95,4 +98,8 @@ func makeRemoteEngine(listenAddr string) *actor.Engine {
 	r := New(e, Config{ListenAddr: listenAddr})
 	e.WithRemote(r)
 	return e
+}
+
+func getRandomLocalhostAddr() string {
+	return fmt.Sprintf("localhost:%d", rand.Intn(50000)+10000)
 }

--- a/safemap/safemap.go
+++ b/safemap/safemap.go
@@ -3,45 +3,40 @@ package safemap
 import "sync"
 
 type SafeMap[K comparable, V any] struct {
-	mu   sync.RWMutex
-	data map[K]V
+	data sync.Map
 }
 
 func New[K comparable, V any]() *SafeMap[K, V] {
 	return &SafeMap[K, V]{
-		data: make(map[K]V),
+		data: sync.Map{},
 	}
 }
 
 func (s *SafeMap[K, V]) Set(k K, v V) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.data[k] = v
+	s.data.Store(k, v)
 }
 
 func (s *SafeMap[K, V]) Get(k K) (V, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	val, ok := s.data[k]
-	return val, ok
+	val, ok := s.data.Load(k)
+	return val.(V), ok
 }
 
 func (s *SafeMap[K, V]) Delete(k K) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	delete(s.data, k)
+	s.data.Delete(k)
 }
 
 func (s *SafeMap[K, V]) Len() int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return len(s.data)
+	count := 0
+	s.data.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	return count
 }
 
 func (s *SafeMap[K, V]) ForEach(f func(K, V)) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for key, val := range s.data {
-		f(key, val)
-	}
+	s.data.Range(func(key, value interface{}) bool {
+		f(key.(K), value.(V))
+		return true
+	})
 }

--- a/safemap/safemap.go
+++ b/safemap/safemap.go
@@ -18,6 +18,9 @@ func (s *SafeMap[K, V]) Set(k K, v V) {
 
 func (s *SafeMap[K, V]) Get(k K) (V, bool) {
 	val, ok := s.data.Load(k)
+	if !ok {
+		return *new(V), false // Return zero value of type V and false
+	}
 	return val.(V), ok
 }
 

--- a/safemap/safemap_test.go
+++ b/safemap/safemap_test.go
@@ -1,20 +1,97 @@
-package safemap_test
+package safemap
 
 import (
-	"github.com/anthdm/hollywood/safemap"
 	"math/rand"
 	"testing"
 )
 
+func TestNewAndSet(t *testing.T) {
+	sm := New[int, string]()
+	sm.Set(1, "one")
+	sm.Set(2, "two")
+
+	if sm.Len() != 2 {
+		t.Errorf("Expected length 2, got %d", sm.Len())
+	}
+}
+
+func TestGet(t *testing.T) {
+	sm := New[int, string]()
+	sm.Set(1, "one")
+
+	val, ok := sm.Get(1)
+	if !ok || val != "one" {
+		t.Errorf("Expected 'one', got %s", val)
+	}
+	_, ok = sm.Get(2)
+	if ok {
+		t.Errorf("Expected false, got true")
+	}
+}
+
+func TestDelete(t *testing.T) {
+	sm := New[int, string]()
+	sm.Set(1, "one")
+	sm.Delete(1)
+	_, ok := sm.Get(1)
+	if ok {
+		t.Errorf("Expected key 1 to be deleted")
+	}
+
+	sm.Delete(2) // just make sure this doesn't panic
+}
+
+func TestLen(t *testing.T) {
+	sm := New[int, string]()
+	sm.Set(1, "one")
+	sm.Set(2, "two")
+	sm.Set(3, "three")
+	sm.Delete(2)
+
+	if sm.Len() != 2 {
+		t.Errorf("Expected length 2, got %d", sm.Len())
+	}
+}
+
+func TestForEach(t *testing.T) {
+	sm := New[int, string]()
+	sm.Set(1, "one")
+	sm.Set(2, "two")
+
+	keys := make([]int, 0)
+	sm.ForEach(func(k int, v string) {
+		keys = append(keys, k)
+	})
+
+	if len(keys) != 2 {
+		t.Errorf("Expected 2 keys, got %d", len(keys))
+	}
+
+	// Check if keys 1 and 2 are present
+	if !contains(keys, 1) || !contains(keys, 2) {
+		t.Errorf("Expected keys 1 and 2, got %v", keys)
+	}
+}
+
+// Helper function to check if a slice contains a specific element.
+func contains(slice []int, element int) bool {
+	for _, a := range slice {
+		if a == element {
+			return true
+		}
+	}
+	return false
+}
+
 // Benchmark Get
 func BenchmarkGetConcurrent(b *testing.B) {
-	ds := safemap.New[uint64, uint64]()
+	ds := New[uint64, uint64]()
 	// Pre-fill the data store with test data if needed
 	for i := 0; i < 100000; i++ {
 		ds.Set(uint64(i), uint64(i))
 	}
+	b.SetParallelism(100)
 	b.ResetTimer()
-
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			r := rand.Uint64() % 100000
@@ -23,14 +100,22 @@ func BenchmarkGetConcurrent(b *testing.B) {
 	})
 }
 
+// fool the compiler
+var silly uint64
+
 // Benchmark Set
 func BenchmarkSetConcurrent(b *testing.B) {
-	ds := safemap.New[uint64, uint64]()
+	ds := New[uint64, uint64]()
+	b.SetParallelism(100)
 	b.ResetTimer()
+
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			r := rand.Uint64() % 100000
+			silly, _ = ds.Get(r)
 			ds.Set(r, r)
+			silly, _ = ds.Get(r)
+
 		}
 	})
 }

--- a/safemap/safemap_test.go
+++ b/safemap/safemap_test.go
@@ -1,0 +1,36 @@
+package safemap_test
+
+import (
+	"github.com/anthdm/hollywood/safemap"
+	"math/rand"
+	"testing"
+)
+
+// Benchmark Get
+func BenchmarkGetConcurrent(b *testing.B) {
+	ds := safemap.New[uint64, uint64]()
+	// Pre-fill the data store with test data if needed
+	for i := 0; i < 100000; i++ {
+		ds.Set(uint64(i), uint64(i))
+	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r := rand.Uint64() % 100000
+			_, _ = ds.Get(r)
+		}
+	})
+}
+
+// Benchmark Set
+func BenchmarkSetConcurrent(b *testing.B) {
+	ds := safemap.New[uint64, uint64]()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			r := rand.Uint64() % 100000
+			ds.Set(r, r)
+		}
+	})
+}


### PR DESCRIPTION
sync.Map is quite fast, in particular for reads (5-10x). It's a bit slower for writes, but not much. On a Mac, a combination of 2 Gets and a Set will get a speedup of 2.5x with this PR. 

I was planning to remove the whole package but as sync.Map isn't really type safe, I think we should keep it around so we have a type-safe map. The wrapper shouldn't impact performance, I think.

This PR should be ready to merge if you want it.