### PR TITLE
Adding a context to the remote for shutdown.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ build:
 	go build -o bin/restarts examples/restarts/main.go 
 	go build -o bin/eventstream examples/eventstream/main.go 
 	go build -o bin/tcpserver examples/tcpserver/main.go 
-	go build -o bin/metrics examples/metrics/main.go 
+	go build -o bin/metrics examples/metrics/main.go
+	go build -o bin/chatserver examples/chat/server/main.go
+	go build -o bin/chatclient examples/chat/client/main.go
 
 bench:
 	go run _bench/main.go

--- a/_bench/main.go
+++ b/_bench/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"os"
@@ -14,7 +15,12 @@ import (
 func makeRemoteEngine(addr string) *actor.Engine {
 	e := actor.NewEngine()
 	r := remote.New(e, remote.Config{ListenAddr: addr})
-	e.WithRemote(r)
+
+	err := e.WithRemote(context.Background(), r)
+	if err != nil {
+		slog.Error("WithRemote", "error", err)
+		os.Exit(1)
+	}
 	return e
 }
 

--- a/actor/logger.go
+++ b/actor/logger.go
@@ -1,0 +1,9 @@
+package actor
+
+import "github.com/anthdm/hollywood/log"
+
+// GetLogger returns the logger used by the engine, this is needed for the remote
+// to be able to log. It shouldn't be used by anything else.
+func (e *Engine) GetLogger() log.Logger {
+	return e.logger
+}

--- a/examples/chat/client/main.go
+++ b/examples/chat/client/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"flag"
 	"fmt"
 	"github.com/anthdm/hollywood/log"
@@ -50,9 +51,16 @@ func main() {
 	e := actor.NewEngine(actor.EngineOptLogger(log.Default()))
 	rem := remote.New(e, remote.Config{
 		ListenAddr: *listenAt,
-		Logger:     log.NewLogger("[remote]", log.NewHandler(os.Stdout, log.TextFormat, slog.LevelDebug)),
+		// perbu:
+		// Logger:     log.NewLogger("[remote]", log.NewHandler(os.Stdout, log.TextFormat, slog.LevelDebug)),
 	})
-	e.WithRemote(rem)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := e.WithRemote(ctx, rem)
+	if err != nil {
+		slog.Error("WithRemote", "error", err)
+		os.Exit(1)
+	}
 
 	var (
 		// the process ID of the server

--- a/examples/chat/server/main.go
+++ b/examples/chat/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log/slog"
 
@@ -61,7 +62,10 @@ func main() {
 	rem := remote.New(e, remote.Config{
 		ListenAddr: *listenAt,
 	})
-	e.WithRemote(rem)
+	err := e.WithRemote(context.TODO(), rem)
+	if err != nil {
+		panic(err)
+	}
 	e.Spawn(newServer, "server")
 
 	select {}

--- a/examples/remote/client/main.go
+++ b/examples/remote/client/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"context"
+	"fmt"
+	"github.com/anthdm/hollywood/log"
 	"time"
 
 	"github.com/anthdm/hollywood/actor"
@@ -9,13 +12,19 @@ import (
 )
 
 func main() {
-	e := actor.NewEngine()
+	e := actor.NewEngine(actor.EngineOptLogger(log.Debug()))
 	r := remote.New(e, remote.Config{ListenAddr: "127.0.0.1:3000"})
-	e.WithRemote(r)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := e.WithRemote(ctx, r)
+	if err != nil {
+		panic(err)
+	}
 
 	pid := actor.NewPID("127.0.0.1:4000", "server")
 	for {
 		e.Send(pid, &msg.Message{Data: "hello!"})
+		fmt.Println("sent message")
 		time.Sleep(time.Second)
 	}
 }

--- a/examples/remote/server/main.go
+++ b/examples/remote/server/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"github.com/anthdm/hollywood/log"
 
 	"github.com/anthdm/hollywood/actor"
 	"github.com/anthdm/hollywood/examples/remote/msg"
@@ -26,9 +28,14 @@ func (f *server) Receive(ctx *actor.Context) {
 }
 
 func main() {
-	e := actor.NewEngine()
+	e := actor.NewEngine(actor.EngineOptLogger(log.Debug()))
 	r := remote.New(e, remote.Config{ListenAddr: "127.0.0.1:4000"})
-	e.WithRemote(r)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	err := e.WithRemote(ctx, r)
+	if err != nil {
+		panic(err)
+	}
 
 	e.Spawn(newServer, "server")
 	select {}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.20
 
 require (
 	github.com/planetscale/vtprotobuf v0.4.0
+	github.com/prometheus/client_golang v1.15.0
+	github.com/redis/go-redis/v9 v9.0.4
 	github.com/stretchr/testify v1.8.1
 	google.golang.org/grpc v1.53.0
 	google.golang.org/protobuf v1.30.0
@@ -17,11 +19,9 @@ require (
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/prometheus/client_golang v1.15.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
-	github.com/redis/go-redis/v9 v9.0.4 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 

--- a/log/log.go
+++ b/log/log.go
@@ -47,6 +47,12 @@ func Default() Logger {
 	return NewLogger("[engine]", NewHandler(os.Stdout, TextFormat, slog.LevelInfo))
 }
 
+// Debug returns a logger that logs to stdout with the
+// TextFormat and log level Debug. This is the recommended logger to use when debugging.
+func Debug() Logger {
+	return NewLogger("[engine]", NewHandler(os.Stdout, TextFormat, slog.LevelDebug))
+}
+
 func NewHandler(w io.Writer, format LoggerFormat, loglevel slog.Level) slog.Handler {
 	switch format {
 	case JsonFormat:


### PR DESCRIPTION
one major change. engine.WithRemote now takes a context, which is passed to the remote. It will shut down the remote when the context is cancelled.

one minor change. The engine now has a GetLogger() which responds with the logger, so the remote can set up logging on its own. previously you had to supply a logger directly to the remote, which is cumbersome and error prone.

I've tried and failed to avoid adding another method to the engine to do this. The alternative would be to make the remote package internal, meaning the user would not be able to import the remote package directly.

trivial changes: 
- The make files now also builds the examples using the remote.
- the log package contains a Debug() which returns a logger with debug level preset. Useful when developing tests.
- I've also tried to document some functions which had missing or imcomplete docs.

Todo: Since the remote now can be shut down, how should the remote behave in it's shutdown state? Should it have a flag indicating that it is still active? Should it panic when somebody tries to use it? Please advice.

Todo: When expanding on the tests to check that we actually stop listening to the socket I didn't find a nice way to figure out if the remote has completed cancelling the remote. Any ideas here? cancel() is async so it might take a few microseconds. It seems to work on my computer, though, syscalls are slow, I guess.