### PR TITLE
add a test that deadlocks the engine.

### DIFF
--- a/actor/engine_test.go
+++ b/actor/engine_test.go
@@ -189,6 +189,17 @@ func TestSpawn(t *testing.T) {
 	wg.Wait()
 }
 
+func TestSpawnDuplicateId(t *testing.T) {
+	e, err := NewEngine()
+	require.NoError(t, err)
+	wg := sync.WaitGroup{}
+	pid1 := e.Spawn(NewTestProducer(t, func(t *testing.T, ctx *Context) {}), "dummy")
+	e.Send(pid1, 1)
+	pid2 := e.Spawn(NewTestProducer(t, func(t *testing.T, ctx *Context) {}), "dummy")
+	e.Send(pid2, 2)
+	wg.Wait()
+}
+
 func TestStopWaitGroup(t *testing.T) {
 	var (
 		wg = sync.WaitGroup{}

--- a/actor/registry.go
+++ b/actor/registry.go
@@ -49,11 +49,13 @@ func (r *Registry) getByID(id string) Processer {
 // decide?
 func (r *Registry) add(proc Processer) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
+
 	id := proc.PID().ID
 	if _, ok := r.lookup[id]; ok {
+		r.mu.Unlock()
 		r.engine.BroadcastEvent(ActorDuplicateIdEvent{PID: proc.PID()})
 		return
 	}
 	r.lookup[id] = proc
+	r.mu.Unlock()
 }


### PR DESCRIPTION
creating two actors with the same id deadlocks the engine. It seems like a mutex is held in the registry.