### PR TITLE
cleans up the stack trace,

### DIFF
--- a/actor/engine_test.go
+++ b/actor/engine_test.go
@@ -124,7 +124,7 @@ func TestRestarts(t *testing.T) {
 			if msg.data != 10 {
 				panic("I failed to process this message")
 			} else {
-				fmt.Println("finally processed all my messsages after borking.", msg.data)
+				fmt.Println("finally processed all my messages after borking", msg.data)
 				wg.Done()
 			}
 		}

--- a/actor/process.go
+++ b/actor/process.go
@@ -1,7 +1,9 @@
 package actor
 
 import (
+	"bytes"
 	"fmt"
+	"github.com/DataDog/gostackparse"
 	"log/slog"
 	"runtime/debug"
 	"sync"
@@ -149,8 +151,7 @@ func (p *process) tryRestart(v any) {
 		p.Start()
 		return
 	}
-	stackTrace := debug.Stack()
-	fmt.Println(string(stackTrace))
+	stackTrace := cleanTrace(debug.Stack())
 	// If we reach the max restarts, we shutdown the inbox and clean
 	// everything up.
 	if p.restarts == p.MaxRestarts {
@@ -210,3 +211,24 @@ func (p *process) Send(_ *PID, msg any, sender *PID) {
 	p.inbox.Send(Envelope{Msg: msg, Sender: sender})
 }
 func (p *process) Shutdown(wg *sync.WaitGroup) { p.cleanup(wg) }
+
+func cleanTrace(stack []byte) []byte {
+	goros, err := gostackparse.Parse(bytes.NewReader(stack))
+	if err != nil {
+		slog.Error("failed to parse stacktrace", "err", err)
+		return stack
+	}
+	if len(goros) != 1 {
+		slog.Error("expected only one goroutine", "goroutines", len(goros))
+		return stack
+	}
+	// skip the first frames:
+	goros[0].Stack = goros[0].Stack[4:]
+	buf := bytes.NewBuffer(nil)
+	_, _ = fmt.Fprintf(buf, "goroutine %d [%s]\n", goros[0].ID, goros[0].State)
+	for _, frame := range goros[0].Stack {
+		_, _ = fmt.Fprintf(buf, "%s\n", frame.Func)
+		_, _ = fmt.Fprint(buf, "\t", frame.File, ":", frame.Line, "\n")
+	}
+	return buf.Bytes()
+}

--- a/actor/process_test.go
+++ b/actor/process_test.go
@@ -1,0 +1,48 @@
+package actor
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"sync"
+	"testing"
+)
+
+// Test_CleanTrace tests that the stack trace is cleaned up correctly and that the function
+// which triggers the panic is at the top of the stack trace.
+func Test_CleanTrace(t *testing.T) {
+	e, err := NewEngine(nil)
+	require.NoError(t, err)
+	type triggerPanic struct {
+		data int
+	}
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	pid := e.SpawnFunc(func(c *Context) {
+		fmt.Printf("Got message type %T\n", c.Message())
+		switch c.Message().(type) {
+		case Started:
+			c.Engine().Subscribe(c.pid)
+		case triggerPanic:
+			panicWrapper()
+		case ActorRestartedEvent:
+			m := c.Message().(ActorRestartedEvent)
+			// split the panic into lines:
+			lines := bytes.Split(m.Stacktrace, []byte("\n"))
+			// check that the second line is the panicWrapper function:
+			if bytes.Contains(lines[1], []byte("panicWrapper")) {
+				fmt.Println("stack trace contains panicWrapper at the right line")
+				wg.Done()
+			} else {
+				t.Error("stack trace does not contain panicWrapper at the right line")
+				t.Fail()
+			}
+		}
+	}, "foo", WithMaxRestarts(1))
+	e.Send(pid, triggerPanic{1})
+	wg.Wait()
+}
+
+func panicWrapper() {
+	panic("foo")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/anthdm/hollywood
 go 1.21
 
 require (
+	github.com/DataDog/gostackparse v0.7.0
 	github.com/grandcat/zeroconf v1.0.0
 	github.com/planetscale/vtprotobuf v0.4.0
 	github.com/prometheus/client_golang v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DataDog/gostackparse v0.7.0 h1:i7dLkXHvYzHV308hnkvVGDL3BR4FWl7IsXNPz/IGQh4=
+github.com/DataDog/gostackparse v0.7.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bsm/ginkgo/v2 v2.7.0 h1:ItPMPH90RbmZJt5GtkcNvIRuGEdwlBItdNVoyzaNQao=
@@ -57,6 +59,7 @@ github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/f
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=


### PR DESCRIPTION
 removing the lines from hollywood itself. the stack trace is still printed, but on a single, long line.
 
 Not sure if we want to continue to print it or not. It is now logged like this:
 
 ```
 2023/12/30 10:27:56 ERROR Actor crashed and restarted pid=foo/4013902862007941006 stack="goroutine 21 [running]\ngithub.com/anthdm/hollywood/actor.TestRestarts.func1\n\t/Users/perbu/git/perbu/hollywood/actor/engine_test.go:125\ngithub.com/anthdm/hollywood/actor.(*funcReceiver).Receive\n\t/Users/perbu/git/perbu/hollywood/actor/engine.go:283\ngithub.com/anthdm/hollywood/actor.(*process).invokeMsg\n\t/Users/perbu/git/perbu/hollywood/actor/process.go:115\ngithub.com/anthdm/hollywood/actor.(*process).Invoke\n\t/Users/perbu/git/perbu/hollywood/actor/process.go:99\ngithub.com/anthdm/hollywood/actor.(*Inbox).run\n\t/Users/perbu/git/perbu/hollywood/actor/inbox.go:86\ngithub.com/anthdm/hollywood/actor.(*Inbox).process\n\t/Users/perbu/git/perbu/hollywood/actor/inbox.go:72\n" reason="I failed to process this message" restarts=1
```
 
 Fixes: #106