### PR TITLE
add the WithContext option

### DIFF
--- a/actor/context.go
+++ b/actor/context.go
@@ -1,6 +1,7 @@
 package actor
 
 import (
+	"context"
 	"log/slog"
 	"math"
 	"math/rand"
@@ -21,14 +22,22 @@ type Context struct {
 	// when the child dies.
 	parentCtx *Context
 	children  *safemap.SafeMap[string, *PID]
+	context   context.Context
 }
 
-func newContext(e *Engine, pid *PID) *Context {
+func newContext(ctx context.Context, e *Engine, pid *PID) *Context {
 	return &Context{
+		context:  ctx,
 		engine:   e,
 		pid:      pid,
 		children: safemap.New[string, *PID](),
 	}
+}
+
+// Context returns a context.Context, user defined on spawn or
+// a context.Background as default
+func (c *Context) Context() context.Context {
+	return c.context
 }
 
 // Receiver returns the underlying receiver of this Context.

--- a/actor/engine_test.go
+++ b/actor/engine_test.go
@@ -1,6 +1,7 @@
 package actor
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"sync"
@@ -34,6 +35,24 @@ func newTickReceiver(wg *sync.WaitGroup) Producer {
 			wg: wg,
 		}
 	}
+}
+
+func TestSpawnWithContext(t *testing.T) {
+	e, _ := NewEngine(nil)
+	type key struct {
+		key string
+	}
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	ctx := context.WithValue(context.Background(), key{"foo"}, "bar")
+	e.SpawnFunc(func(c *Context) {
+		switch c.Message().(type) {
+		case Started:
+			assert.Equal(t, "bar", ctx.Value(key{"foo"}))
+			wg.Done()
+		}
+	}, "test", WithContext(ctx))
+	wg.Wait()
 }
 
 func TestRegistryGetPID(t *testing.T) {

--- a/actor/opts.go
+++ b/actor/opts.go
@@ -1,6 +1,7 @@
 package actor
 
 import (
+	"context"
 	"time"
 )
 
@@ -23,6 +24,7 @@ type Opts struct {
 	RestartDelay time.Duration
 	InboxSize    int
 	Middleware   []MiddlewareFunc
+	Context      context.Context
 }
 
 type OptFunc func(*Opts)
@@ -30,11 +32,18 @@ type OptFunc func(*Opts)
 // DefaultOpts returns default options from the given Producer.
 func DefaultOpts(p Producer) Opts {
 	return Opts{
+		Context:      context.Background(),
 		Producer:     p,
 		MaxRestarts:  defaultMaxRestarts,
 		InboxSize:    defaultInboxSize,
 		RestartDelay: defaultRestartDelay,
 		Middleware:   []MiddlewareFunc{},
+	}
+}
+
+func WithContext(ctx context.Context) OptFunc {
+	return func(opts *Opts) {
+		opts.Context = ctx
 	}
 }
 

--- a/actor/process.go
+++ b/actor/process.go
@@ -3,11 +3,12 @@ package actor
 import (
 	"bytes"
 	"fmt"
-	"github.com/DataDog/gostackparse"
 	"log/slog"
 	"runtime/debug"
 	"sync"
 	"time"
+
+	"github.com/DataDog/gostackparse"
 )
 
 type Envelope struct {
@@ -24,11 +25,6 @@ type Processer interface {
 	Shutdown(*sync.WaitGroup)
 }
 
-const (
-	procStateRunning int32 = iota
-	procStateStopped
-)
-
 type process struct {
 	Opts
 
@@ -36,13 +32,12 @@ type process struct {
 	context  *Context
 	pid      *PID
 	restarts int32
-
-	mbuffer []Envelope
+	mbuffer  []Envelope
 }
 
 func newProcess(e *Engine, opts Opts) *process {
 	pid := NewPID(e.address, opts.Kind+pidSeparator+opts.ID)
-	ctx := newContext(e, pid)
+	ctx := newContext(opts.Context, e, pid)
 	p := &process{
 		pid:     pid,
 		inbox:   NewInbox(opts.InboxSize),


### PR DESCRIPTION
Users are now able to pass a context.Context. This is super handy when spawning goroutines from actors that need values passed down or cancelation