### PR TITLE
Fix cleanup of children

### DIFF
--- a/actor/context_test.go
+++ b/actor/context_test.go
@@ -75,7 +75,8 @@ func TestSpawnChildPID(t *testing.T) {
 
 func TestChild(t *testing.T) {
 	var (
-		wg = sync.WaitGroup{}
+		wg     = sync.WaitGroup{}
+		stopWg = sync.WaitGroup{}
 	)
 	e, err := NewEngine(NewEngineConfig())
 	require.NoError(t, err)
@@ -88,6 +89,9 @@ func TestChild(t *testing.T) {
 			c.SpawnChildFunc(func(_ *Context) {}, "child", WithID("3"))
 		case Started:
 			assert.Equal(t, 3, len(c.Children()))
+			c.Engine().Stop(c.Children()[0], &stopWg)
+			stopWg.Wait()
+			assert.Equal(t, 2, len(c.Children()))
 			wg.Done()
 		}
 	}, "foo", WithID("bar/baz"))

--- a/actor/process.go
+++ b/actor/process.go
@@ -179,7 +179,7 @@ func (p *process) tryRestart(v any) {
 
 func (p *process) cleanup(wg *sync.WaitGroup) {
 	if p.context.parentCtx != nil {
-		p.context.parentCtx.children.Delete(p.Kind)
+		p.context.parentCtx.children.Delete(p.pid.ID)
 	}
 
 	if p.context.children.Len() > 0 {


### PR DESCRIPTION
I noticed that after stopping a child it's PID was still listed in contexts children map. Extended test case and fixed the bug