### PR TITLE
Fix race condition during actor startup sequence

### DIFF
--- a/actor/inbox.go
+++ b/actor/inbox.go
@@ -13,9 +13,10 @@ const (
 )
 
 const (
-	idle int32 = iota
+	stopped int32 = iota
+	starting
+	idle
 	running
-	stopped
 )
 
 type Scheduler interface {
@@ -52,8 +53,9 @@ type Inbox struct {
 
 func NewInbox(size int) *Inbox {
 	return &Inbox{
-		rb:        ringbuffer.New[Envelope](int64(size)),
-		scheduler: NewScheduler(defaultThroughput),
+		rb:         ringbuffer.New[Envelope](int64(size)),
+		scheduler:  NewScheduler(defaultThroughput),
+		procStatus: stopped,
 	}
 }
 
@@ -91,7 +93,12 @@ func (in *Inbox) run() {
 }
 
 func (in *Inbox) Start(proc Processer) {
-	in.proc = proc
+	// transition to "starting" and then "idle" to ensure no race condition on in.proc
+	if atomic.CompareAndSwapInt32(&in.procStatus, stopped, starting) {
+		in.proc = proc
+		atomic.SwapInt32(&in.procStatus, idle)
+		in.schedule()
+	}
 }
 
 func (in *Inbox) Stop() error {

--- a/actor/process.go
+++ b/actor/process.go
@@ -45,7 +45,6 @@ func newProcess(e *Engine, opts Opts) *process {
 		context: ctx,
 		mbuffer: nil,
 	}
-	p.inbox.Start(p)
 	return p
 }
 
@@ -138,6 +137,8 @@ func (p *process) Start() {
 		p.Invoke(p.mbuffer)
 		p.mbuffer = nil
 	}
+
+	p.inbox.Start(p)
 }
 
 func (p *process) tryRestart(v any) {


### PR DESCRIPTION
This PR is intended to fix the issue #159.

The race condition occurs when a msg is sent to an actor while it is still processing the actor.Initialized or actor.Started msg. This can easily happen when loading some state from a db when processing one of these startup msgs. 

I am proposing that the inbox only be started after the actor has processed all the startup msgs. This requires some changes to the inbox:
- initialize the procStatus to "stopped"
- when Start() is called, transition to "starting" and then "idle" status, and then call schedule() to process queued msgs

I have added a test case to test the proper ordering of msgs under this scenario.