### PR TITLE
Fix poison deadlocking on non-existing pids

### DIFF
--- a/actor/engine_test.go
+++ b/actor/engine_test.go
@@ -316,6 +316,8 @@ func TestPoisonWaitGroup(t *testing.T) {
 	case <-time.After(20 * time.Millisecond):
 		t.Error("poison waitGroup deadlocked")
 	}
+	// ... or panic
+	e.Poison(nil).Wait()
 }
 
 func TestPoison(t *testing.T) {

--- a/actor/registry.go
+++ b/actor/registry.go
@@ -40,6 +40,9 @@ func (r *Registry) Remove(pid *PID) {
 // If it doesn't exist, nil is returned so the caller must check for that
 // and direct the message to the deadletter processer instead.
 func (r *Registry) get(pid *PID) Processer {
+	if pid == nil {
+		return nil
+	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	if proc, ok := r.lookup[pid.ID]; ok {


### PR DESCRIPTION
When poisoning a non-existing (e.g. already crashed) pid, the waitGroup would deadlock. 

Added test and fixed by only incrementing waitGroup if the process was found.