### PR TITLE
Bugfix - Stopped message processed mutliple times on shutdown

### DIFF
--- a/actor/engine_test.go
+++ b/actor/engine_test.go
@@ -463,3 +463,21 @@ func NewTestProducer(t *testing.T, f TestReceiveFunc) Producer {
 func (r *TestReceiver) Receive(ctx *Context) {
 	r.OnReceive(r.t, ctx)
 }
+
+func TestMultipleStops(t *testing.T) {
+	e, err := NewEngine(NewEngineConfig())
+	require.NoError(t, err)
+	for i := 0; i < 1000; i++ {
+		done := make(chan struct{})
+		pid := e.SpawnFunc(func(ctx *Context) {
+			switch ctx.Message().(type) {
+			case Stopped:
+				close(done)
+			}
+		}, "test")
+		for j := 0; j < 10; j++ {
+			e.Stop(pid)
+		}
+		<-done
+	}
+}

--- a/actor/inbox.go
+++ b/actor/inbox.go
@@ -72,9 +72,7 @@ func (in *Inbox) schedule() {
 
 func (in *Inbox) process() {
 	in.run()
-	if atomic.LoadInt32(&in.procStatus) != stopped {
-		atomic.StoreInt32(&in.procStatus, idle)
-	}
+	atomic.CompareAndSwapInt32(&in.procStatus, running, idle)
 }
 
 func (in *Inbox) run() {

--- a/actor/inbox.go
+++ b/actor/inbox.go
@@ -13,10 +13,11 @@ const (
 )
 
 const (
-	stopped int32 = iota
+	new int32 = iota
 	starting
 	idle
 	running
+	stopped
 )
 
 type Scheduler interface {
@@ -55,7 +56,7 @@ func NewInbox(size int) *Inbox {
 	return &Inbox{
 		rb:         ringbuffer.New[Envelope](int64(size)),
 		scheduler:  NewScheduler(defaultThroughput),
-		procStatus: stopped,
+		procStatus: new,
 	}
 }
 
@@ -96,7 +97,7 @@ func (in *Inbox) run() {
 
 func (in *Inbox) Start(proc Processer) {
 	// transition to "starting" and then "idle" to ensure no race condition on in.proc
-	if atomic.CompareAndSwapInt32(&in.procStatus, stopped, starting) {
+	if atomic.CompareAndSwapInt32(&in.procStatus, new, starting) {
 		in.proc = proc
 		atomic.SwapInt32(&in.procStatus, idle)
 		in.schedule()

--- a/actor/inbox.go
+++ b/actor/inbox.go
@@ -13,11 +13,10 @@ const (
 )
 
 const (
-	new int32 = iota
+	stopped int32 = iota
 	starting
 	idle
 	running
-	stopped
 )
 
 type Scheduler interface {
@@ -56,7 +55,7 @@ func NewInbox(size int) *Inbox {
 	return &Inbox{
 		rb:         ringbuffer.New[Envelope](int64(size)),
 		scheduler:  NewScheduler(defaultThroughput),
-		procStatus: new,
+		procStatus: stopped,
 	}
 }
 
@@ -73,7 +72,7 @@ func (in *Inbox) schedule() {
 
 func (in *Inbox) process() {
 	in.run()
-	if in.procStatus != stopped {
+	if atomic.LoadInt32(&in.procStatus) != stopped {
 		atomic.StoreInt32(&in.procStatus, idle)
 	}
 }
@@ -97,7 +96,7 @@ func (in *Inbox) run() {
 
 func (in *Inbox) Start(proc Processer) {
 	// transition to "starting" and then "idle" to ensure no race condition on in.proc
-	if atomic.CompareAndSwapInt32(&in.procStatus, new, starting) {
+	if atomic.CompareAndSwapInt32(&in.procStatus, stopped, starting) {
 		in.proc = proc
 		atomic.SwapInt32(&in.procStatus, idle)
 		in.schedule()

--- a/actor/inbox.go
+++ b/actor/inbox.go
@@ -72,7 +72,9 @@ func (in *Inbox) schedule() {
 
 func (in *Inbox) process() {
 	in.run()
-	atomic.StoreInt32(&in.procStatus, idle)
+	if in.procStatus != stopped {
+		atomic.StoreInt32(&in.procStatus, idle)
+	}
 }
 
 func (in *Inbox) run() {

--- a/actor/inbox_test.go
+++ b/actor/inbox_test.go
@@ -45,7 +45,7 @@ func (m MockProcesser) Invoke(envelopes []Envelope) {
 }
 func (m MockProcesser) Shutdown(_ *sync.WaitGroup) {}
 
-func TestStopInbox(t *testing.T) {
+func TestInboxStop(t *testing.T) {
 	inbox := NewInbox(10)
 	done := make(chan struct{})
 	mockProc := MockProcesser{


### PR DESCRIPTION
This is the fix for the bug described here #170

The source of this bug is the inbox.procStatus being incorrectly set to "idle" after the posionPill stops the inbox. The procStatus should only be set to "idle" if the procStatus is "running". 

I added 2 tests:
- TestInboxStop - unit test for the inbox
- TestMultipleStops - integration test