### PR TITLE
remote unreachable event when message fails to be sent remotely

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -36,7 +36,6 @@ type Remote struct {
 	addr            string
 	engine          *actor.Engine
 	config          Config
-	streamReader    *streamReader
 	streamRouterPID *actor.PID
 	stopCh          chan struct{} // Stop closes this channel to signal the remote to stop listening.
 	stopWg          *sync.WaitGroup
@@ -57,7 +56,6 @@ func New(addr string, config Config) *Remote {
 		config: config,
 	}
 	r.state.Store(stateInitialized)
-	r.streamReader = newStreamReader(r)
 	return r
 }
 
@@ -81,7 +79,7 @@ func (r *Remote) Start(e *actor.Engine) error {
 	}
 	slog.Debug("listening", "addr", r.addr)
 	mux := drpcmux.New()
-	err = DRPCRegisterRemote(mux, r.streamReader)
+	err = DRPCRegisterRemote(mux, newStreamReader(r))
 	if err != nil {
 		return fmt.Errorf("failed to register remote: %w", err)
 	}

--- a/remote/stream_router.go
+++ b/remote/stream_router.go
@@ -13,10 +13,6 @@ type streamDeliver struct {
 	msg    any
 }
 
-type terminateStream struct {
-	address string
-}
-
 type streamRouter struct {
 	engine *actor.Engine
 	// streams is a map of remote address to stream writer pid.
@@ -41,16 +37,16 @@ func (s *streamRouter) Receive(ctx *actor.Context) {
 		s.pid = ctx.PID()
 	case *streamDeliver:
 		s.deliverStream(msg)
-	case terminateStream:
+	case actor.RemoteUnreachableEvent:
 		s.handleTerminateStream(msg)
 	}
 }
 
-func (s *streamRouter) handleTerminateStream(msg terminateStream) {
-	streamWriterPID := s.streams[msg.address]
-	delete(s.streams, msg.address)
-	slog.Debug("terminating stream",
-		"remote", msg.address,
+func (s *streamRouter) handleTerminateStream(msg actor.RemoteUnreachableEvent) {
+	streamWriterPID := s.streams[msg.ListenAddr]
+	delete(s.streams, msg.ListenAddr)
+	slog.Debug("stream terminated",
+		"remote", msg.ListenAddr,
 		"pid", streamWriterPID,
 	)
 }

--- a/remote/stream_writer.go
+++ b/remote/stream_writer.go
@@ -141,10 +141,6 @@ func (s *streamWriter) init() {
 	// We could not reach the remote after retrying N times. Hence, shutdown the stream writer.
 	// and notify RemoteUnreachableEvent.
 	if rawconn == nil {
-		evt := actor.RemoteUnreachableEvent{
-			ListenAddr: s.writeToAddr,
-		}
-		s.engine.BroadcastEvent(evt)
 		s.Shutdown(nil)
 		return
 	}


### PR DESCRIPTION
Currently, the engine broadcasts `RemoteUnreachableEvent` only if it fails to initiate the connection with the remote.
It might happen that the remote connection is initiated successfully, but the message fails to be delivered later. 