### PR TITLE
[BUG FIX] Message not delivered to Processor

### DIFF
--- a/actor/inbox_test.go
+++ b/actor/inbox_test.go
@@ -46,7 +46,7 @@ func TestInboxSendAndProcessMany(t *testing.T) {
 		msg := Envelope{}
 		inbox.Send(msg)
 
-		timer := time.NewTimer(10 * time.Millisecond)
+		timer := time.NewTimer(time.Second)
 		select {
 		case <-processedMessages: // Message processed
 		case <-timer.C:

--- a/actor/inbox_test.go
+++ b/actor/inbox_test.go
@@ -31,6 +31,33 @@ func TestInboxSendAndProcess(t *testing.T) {
 	inbox.Stop()
 }
 
+func TestInboxSendAndProcessMany(t *testing.T) {
+	for i := 0; i < 100000; i++ {
+		inbox := NewInbox(10)
+		processedMessages := make(chan Envelope, 10)
+		mockProc := MockProcesser{
+			processFunc: func(envelopes []Envelope) {
+				for _, e := range envelopes {
+					processedMessages <- e
+				}
+			},
+		}
+		inbox.Start(mockProc)
+		msg := Envelope{}
+		inbox.Send(msg)
+
+		timer := time.NewTimer(10 * time.Millisecond)
+		select {
+		case <-processedMessages: // Message processed
+		case <-timer.C:
+			t.Errorf("Message was not processed in time")
+		}
+		timer.Stop()
+
+		inbox.Stop()
+	}
+}
+
 type MockProcesser struct {
 	processFunc func([]Envelope)
 }


### PR DESCRIPTION
This PR is a bugfix for issue #173.

We must check if the ring-buffer has messages after transitioning the procStatus to "idle". If there are messages, then we should schedule again.

I added a test that can somewhat reliably reproduce the issue. However, the test takes about 2 seconds to run on my machine.