### PR TITLE
avoid 2 atomic locks on inbox process

### DIFF
--- a/actor/inbox.go
+++ b/actor/inbox.go
@@ -75,7 +75,7 @@ func (in *Inbox) process() {
 	if in.rb.Len() > 0 {
 		in.scheduler.Schedule(in.process)
 	} else {
-		atomic.StoreInt32(&in.procStatus, idle)
+		atomic.CompareAndSwapInt32(&in.procStatus, running, idle)
 	}
 }
 

--- a/actor/inbox.go
+++ b/actor/inbox.go
@@ -72,10 +72,10 @@ func (in *Inbox) schedule() {
 
 func (in *Inbox) process() {
 	in.run()
-	if atomic.CompareAndSwapInt32(&in.procStatus, running, idle) && in.rb.Len() > 0 {
-		// messages might have been added to the ring-buffer between the last pop and the transition to idle.
-		// if this is the case, then we should schedule again
-		in.schedule()
+	if in.rb.Len() > 0 {
+		in.scheduler.Schedule(in.process)
+	} else {
+		atomic.StoreInt32(&in.procStatus, idle)
 	}
 }
 


### PR DESCRIPTION
if inbox contained messages, the `procStatus` was changed from `running` to `idle` and from `idle` to `running` immediately. We can avoid this multiple atomic swap by checking the ring buffer length. If there are no messages, the `procStatus` can be safely changed to idle.