### PR TITLE
Bugfix // Fix race condition in `Pop` & `PopN` operation of ring buffer

### DIFF
--- a/ringbuffer/ringbuffer.go
+++ b/ringbuffer/ringbuffer.go
@@ -61,6 +61,11 @@ func (rb *RingBuffer[T]) Pop() (T, bool) {
 		return t, false
 	}
 	rb.mu.Lock()
+	if rb.len == 0 {
+		rb.mu.Unlock()
+		var t T
+		return t, false
+	}
 	rb.content.head = (rb.content.head + 1) % rb.content.mod
 	item := rb.content.items[rb.content.head]
 	var t T
@@ -75,6 +80,10 @@ func (rb *RingBuffer[T]) PopN(n int64) ([]T, bool) {
 		return nil, false
 	}
 	rb.mu.Lock()
+	if rb.len == 0 {
+		rb.mu.Unlock()
+		return nil, false
+	}
 	content := rb.content
 
 	if n >= rb.len {

--- a/ringbuffer/ringbuffer.go
+++ b/ringbuffer/ringbuffer.go
@@ -56,10 +56,6 @@ func (rb *RingBuffer[T]) Len() int64 {
 }
 
 func (rb *RingBuffer[T]) Pop() (T, bool) {
-	if rb.Len() == 0 {
-		var t T
-		return t, false
-	}
 	rb.mu.Lock()
 	if rb.len == 0 {
 		rb.mu.Unlock()
@@ -76,9 +72,6 @@ func (rb *RingBuffer[T]) Pop() (T, bool) {
 }
 
 func (rb *RingBuffer[T]) PopN(n int64) ([]T, bool) {
-	if rb.Len() == 0 {
-		return nil, false
-	}
 	rb.mu.Lock()
 	if rb.len == 0 {
 		rb.mu.Unlock()

--- a/ringbuffer/ringbuffer_test.go
+++ b/ringbuffer/ringbuffer_test.go
@@ -1,6 +1,8 @@
 package ringbuffer
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -36,4 +38,58 @@ func TestPushPopN(t *testing.T) {
 			t.Fatal("invalid item popped")
 		}
 	}
+}
+
+func TestPopThreadSafety(t *testing.T) {
+	t.Run("Pop should be thread-safe", func(t *testing.T) {
+		testCase := func() {
+			rb := New[int](4)
+			rb.Push(1)
+			wg := sync.WaitGroup{}
+			for i := 0; i < 2; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					rb.Pop()
+				}()
+			}
+			wg.Wait()
+			if rb.Len() == -1 {
+				t.Fatal("item popped twice")
+			}
+		}
+
+		// Increase the number of iterations to raise the likelihood of reproducing the race condition
+		for i := 0; i < 100_000; i++ {
+			testCase()
+		}
+	})
+
+	t.Run("PopN should be thread-safe", func(t *testing.T) {
+		testCase := func() {
+			rb := New[int](4)
+			rb.Push(1)
+			counter := atomic.Int32{}
+			wg := sync.WaitGroup{}
+			for i := 0; i < 2; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					_, ok := rb.PopN(1)
+					if ok {
+						counter.Add(1)
+					}
+				}()
+			}
+			wg.Wait()
+			if counter.Load() > 1 {
+				t.Fatal("false positive item removal")
+			}
+		}
+
+		// Increase the number of iterations to raise the likelihood of reproducing the race condition
+		for i := 0; i < 100_000; i++ {
+			testCase()
+		}
+	})
 }


### PR DESCRIPTION
The current implementation of the ring buffer has a thread-safety issue in the `Pop` & `PopN` operation.

Attempting to remove an element may lead to a race condition, resulting in the ring buffer being left in an invalid state after calling `Pop`. Similarly, in the case of `PopN`, the method might incorrectly indicate that elements were removed, even though no elements were actually removed because the ring buffer was empty.

To illustrate the problem, I have added unit tests that can reproduce the issue. Feel free to delete these tests once you have verified the existence of the bug, as including such tests might be questionable, given that they expose a non-deterministic problem.