### PR TITLE
Duplicate response issues

### DIFF
--- a/actor/engine_test.go
+++ b/actor/engine_test.go
@@ -480,3 +480,25 @@ func TestMultipleStops(t *testing.T) {
 		<-done
 	}
 }
+
+func TestShouldNotBlockActorOnAccidentalDuplicateRespond(t *testing.T) {
+	e, err := NewEngine(NewEngineConfig())
+	require.NoError(t, err)
+	pid := e.SpawnFunc(func(ctx *Context) {
+		msg := ctx.Message()
+		if s, ok := msg.(string); ok {
+			if s == "foo" {
+				ctx.Respond(len(s))
+				// missing `return` statement, causing an unintended second response
+			}
+			ctx.Respond(len(s)) // sends a duplicate response
+		}
+	}, "str", WithID("len"))
+
+	_ = e.Request(pid, "foo", 2*time.Second) // response will be consumed later
+	resp := e.Request(pid, "barbaz", 2*time.Second)
+
+	r, err := resp.Result()
+	require.NoError(t, err)
+	require.Equal(t, 6, r)
+}

--- a/actor/registry.go
+++ b/actor/registry.go
@@ -69,3 +69,13 @@ func (r *Registry) add(proc Processer) {
 	r.mu.Unlock()
 	proc.Start()
 }
+
+func (r *Registry) remove(pid *PID) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.lookup[pid.ID]
+	if ok {
+		delete(r.lookup, pid.ID)
+	}
+	return ok
+}

--- a/actor/response.go
+++ b/actor/response.go
@@ -40,7 +40,11 @@ func (r *Response) Result() (any, error) {
 }
 
 func (r *Response) Send(_ *PID, msg any, _ *PID) {
-	r.result <- msg
+	// Under normal conditions, the method is expected to be called only once.
+	// To prevent accidental duplicate responses, we promptly remove the process from the registry
+	if r.engine.Registry.remove(r.pid) {
+		r.result <- msg
+	}
 }
 
 func (r *Response) PID() *PID         { return r.pid }


### PR DESCRIPTION
The PR reproduces certain issues caused by responding to a request multiple times. To review the problem, check out the corresponding commit.