### PR TITLE
Retry message failures

### DIFF
--- a/actor/engine_test.go
+++ b/actor/engine_test.go
@@ -91,9 +91,8 @@ func TestRestartsMaxRestarts(t *testing.T) {
 		data int
 	}
 	pid := e.SpawnFunc(func(c *Context) {
+		fmt.Printf("Got message type %T\n", c.Message())
 		switch msg := c.Message().(type) {
-		case Started:
-		case Stopped:
 		case payload:
 			if msg.data != 1 {
 				panic("I failed to process this message")
@@ -101,7 +100,7 @@ func TestRestartsMaxRestarts(t *testing.T) {
 				fmt.Println("finally processed all my messages after borking.", msg.data)
 			}
 		}
-	}, "foo", WithMaxRestarts(restarts))
+	}, "foo", WithMaxRetries(1), WithMaxRestarts(restarts))
 
 	for i := 0; i < 2; i++ {
 		e.Send(pid, payload{i})
@@ -158,7 +157,7 @@ func TestRestarts(t *testing.T) {
 				wg.Done()
 			}
 		}
-	}, "foo", WithRestartDelay(time.Millisecond*10))
+	}, "foo", WithRetries(0), WithRestartDelay(time.Millisecond*10))
 
 	e.Send(pid, payload{1})
 	e.Send(pid, payload{2})

--- a/actor/event.go
+++ b/actor/event.go
@@ -73,6 +73,17 @@ func (e ActorMaxRestartsExceededEvent) Log() (slog.Level, string, []any) {
 	return slog.LevelError, "Actor crashed too many times", []any{"pid", e.PID.GetID()}
 }
 
+// ActorUnprocessableMessageEvent gets published if an actor is unable to process the message after retries
+type ActorUnprocessableMessageEvent struct {
+	PID       *PID
+	Timestamp time.Time
+	Message   any
+}
+
+func (e ActorUnprocessableMessageEvent) Log() (slog.Level, string, []any) {
+	return slog.LevelError, "Actor unable to process message", []any{"pid", e.PID.GetID()}
+}
+
 // ActorDuplicateIdEvent gets published if we try to register the same name twice.
 type ActorDuplicateIdEvent struct {
 	PID *PID

--- a/actor/opts.go
+++ b/actor/opts.go
@@ -8,6 +8,8 @@ import (
 const (
 	defaultInboxSize   = 1024
 	defaultMaxRestarts = 3
+	defaultRetries     = 2
+	defaultMaxRetries  = 2
 )
 
 var defaultRestartDelay = 500 * time.Millisecond
@@ -21,6 +23,8 @@ type Opts struct {
 	Kind         string
 	ID           string
 	MaxRestarts  int32
+	Retries      int32
+	MaxRetries   int32
 	RestartDelay time.Duration
 	InboxSize    int
 	Middleware   []MiddlewareFunc
@@ -35,6 +39,8 @@ func DefaultOpts(p Producer) Opts {
 		Context:      context.Background(),
 		Producer:     p,
 		MaxRestarts:  defaultMaxRestarts,
+		Retries:      defaultRetries,
+		MaxRetries:   defaultMaxRetries,
 		InboxSize:    defaultInboxSize,
 		RestartDelay: defaultRestartDelay,
 		Middleware:   []MiddlewareFunc{},
@@ -68,6 +74,18 @@ func WithInboxSize(size int) OptFunc {
 func WithMaxRestarts(n int) OptFunc {
 	return func(opts *Opts) {
 		opts.MaxRestarts = int32(n)
+	}
+}
+
+func WithRetries(n int) OptFunc {
+	return func(opts *Opts) {
+		opts.Retries = int32(n)
+	}
+}
+
+func WithMaxRetries(n int) OptFunc {
+	return func(opts *Opts) {
+		opts.MaxRetries = int32(n)
 	}
 }
 

--- a/actor/process_test.go
+++ b/actor/process_test.go
@@ -3,45 +3,89 @@ package actor
 import (
 	"bytes"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 )
 
+type triggerPanic struct {
+	data int
+}
+
+func Test_DropsMessageAfterRetries(t *testing.T) {
+	e, err := NewEngine(NewEngineConfig())
+	require.NoError(t, err)
+
+	ch := make(chan any, 1)
+
+	pid := e.SpawnFunc(func(c *Context) {
+		fmt.Printf("Actor state: %T\n", c.Message())
+		switch m := c.Message().(type) {
+		case Started:
+			c.Engine().Subscribe(c.pid)
+		case triggerPanic:
+			if m.data == 2 {
+				panicWrapper()
+			} else {
+				fmt.Println("finally processed message", m.data)
+			}
+		case ActorUnprocessableMessageEvent:
+			fmt.Printf("Got message type %T data:%d\n", m.Message, m.Message.(triggerPanic).data)
+			ch <- m.Message
+		}
+	}, "kind", WithMaxRetries(1))
+
+	e.Send(pid, triggerPanic{1})
+	e.Send(pid, triggerPanic{2})
+	e.Send(pid, triggerPanic{3})
+
+	var messages []any
+	select {
+	case m := <-ch:
+		messages = append(messages, m)
+	case <-time.After(2 * time.Second):
+		t.Error("timeout")
+	}
+	require.Len(t, messages, 1)
+	require.IsType(t, triggerPanic{}, messages[0])
+	require.Equal(t, triggerPanic{data: 2}, messages[0])
+}
+
 // Test_CleanTrace tests that the stack trace is cleaned up correctly and that the function
 // which triggers the panic is at the top of the stack trace.
 func Test_CleanTrace(t *testing.T) {
 	e, err := NewEngine(NewEngineConfig())
 	require.NoError(t, err)
-	type triggerPanic struct {
-		data int
-	}
-	stopCh := make(chan struct{})
+	ch := make(chan any)
 	pid := e.SpawnFunc(func(c *Context) {
 		fmt.Printf("Got message type %T\n", c.Message())
-		switch c.Message().(type) {
+		switch m := c.Message().(type) {
 		case Started:
 			c.Engine().Subscribe(c.pid)
 		case triggerPanic:
-			panicWrapper()
+			if m.data != 10 {
+				panicWrapper()
+			} else {
+				fmt.Println("finally processed all my messages", m.data)
+			}
 		case ActorRestartedEvent:
-			m := c.Message().(ActorRestartedEvent)
 			// split the panic into lines:
 			lines := bytes.Split(m.Stacktrace, []byte("\n"))
-			// check that the second line is the panicWrapper function:
-			if bytes.Contains(lines[1], []byte("panicWrapper")) {
-				fmt.Println("stack trace contains panicWrapper at the right line")
-				stopCh <- struct{}{}
-			}
+			// check that the second line is the panicWrapper function
+			assert.True(t, bytes.Contains(lines[1], []byte("panicWrapper")))
+			close(ch)
 		}
-	}, "foo", WithMaxRestarts(1))
-	e.Send(pid, triggerPanic{1})
+	}, "foo", WithRetries(2), WithMaxRetries(2), WithMaxRestarts(1))
+	e.Send(pid, triggerPanic{2})
+	e.Send(pid, triggerPanic{3})
+	e.Send(pid, triggerPanic{10})
 	select {
-	case <-stopCh:
-		fmt.Println("test passed")
-	case <-time.After(time.Second):
-		t.Error("test timed out. stack trace likely did not contain panicWrapper at the right line")
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Error("test timed out")
+		return
 	}
 }
 


### PR DESCRIPTION
This PR is a continuation of #181 . It introduces two new options `WithRetries` and `WithMaxRetries` and aims to retry message failures on actor panics.

The retry logic is as follows;

`pid := e.SpawnFunc(func(c *Context) {}, "foo", WithRetries(2), WithMaxRetries(2), WithMaxRestarts(1))`

1. Each message that panics is retried up to two times per message `WithRetries(2)`.
2. On the second retry, an `ActorUnprocessableMessageEvent` is broadcast to the eventstream containing the message and the message within the buffer is dropped.
3. Following two consecutive message retries (4 retries), max retries are reached `WithMaxRetries(2).
4. The actor is restarted to restore actor state and the messages left in buffer are resumed except those that were unprocessable.
5. Retries are reset, but assume another two consecutive retries and restart. Max restarts are reached and the actor terminates and cleans up.

Using without retry;

`pid := e.SpawnFunc(func(c *Context) {}, "foo", WithRetries(0), WithMaxRestarts(1))`

1. Each message that panics is dropped and actor is restarted as per original logic.

Included in this PR is a test that covers the full retry logic as well as amended tests.

All other tests pass.