### PR TITLE
Fix actor.Stopped being sent twice under certain conditions

### DIFF
--- a/actor/context.go
+++ b/actor/context.go
@@ -17,6 +17,8 @@ type Context struct {
 	engine   *Engine
 	receiver Receiver
 	message  any
+	// function to get the current number of messages in the inbox
+	getInboxCount func() int
 	// the context of the parent if we are a child.
 	// we need this parentCtx, so we can remove the child from the parent Context
 	// when the child dies.
@@ -31,6 +33,9 @@ func newContext(ctx context.Context, e *Engine, pid *PID) *Context {
 		engine:   e,
 		pid:      pid,
 		children: safemap.New[string, *PID](),
+		getInboxCount: func() int {
+			return -1
+		},
 	}
 }
 
@@ -173,4 +178,9 @@ func (c *Context) Engine() *Engine {
 // Message returns the message that is currently being received.
 func (c *Context) Message() any {
 	return c.message
+}
+
+// GetInboxCount returns the number of messages in the inbox of the current process.
+func (c *Context) GetInboxCount() int {
+	return c.getInboxCount()
 }

--- a/actor/inbox.go
+++ b/actor/inbox.go
@@ -42,6 +42,7 @@ type Inboxer interface {
 	Send(Envelope)
 	Start(Processer)
 	Stop() error
+	Count() int
 }
 
 type Inbox struct {
@@ -108,4 +109,8 @@ func (in *Inbox) Start(proc Processer) {
 func (in *Inbox) Stop() error {
 	atomic.StoreInt32(&in.procStatus, stopped)
 	return nil
+}
+
+func (in *Inbox) Count() int {
+	return int(in.rb.Len())
 }

--- a/actor/process.go
+++ b/actor/process.go
@@ -70,9 +70,6 @@ func (p *process) Invoke(msgs []Envelope) {
 		// If we recovered, we buffer up all the messages that we could not process
 		// so we can retry them on the next restart.
 		if v := recover(); v != nil {
-			p.context.message = Stopped{}
-			p.context.receiver.Receive(p.context)
-
 			p.mbuffer = make([]Envelope, nmsg-nproc)
 			for i := 0; i < nmsg-nproc; i++ {
 				p.mbuffer[i] = msgs[i+nproc]
@@ -121,8 +118,6 @@ func (p *process) Start() {
 	p.context.receiver = recv
 	defer func() {
 		if v := recover(); v != nil {
-			p.context.message = Stopped{}
-			p.context.receiver.Receive(p.context)
 			p.tryRestart(v)
 		}
 	}()
@@ -166,6 +161,9 @@ func (p *process) tryRestart(v any) {
 		return
 	}
 
+	p.context.message = Stopped{}
+	p.context.receiver.Receive(p.context)
+
 	p.restarts++
 	// Restart the process after its restartDelay
 	p.context.engine.BroadcastEvent(ActorRestartedEvent{
@@ -180,7 +178,9 @@ func (p *process) tryRestart(v any) {
 }
 
 func (p *process) cleanup(cancel context.CancelFunc) {
-	defer cancel()
+	if cancel != nil {
+		defer cancel()
+	}
 
 	if p.context.parentCtx != nil {
 		p.context.parentCtx.children.Delete(p.pid.ID)

--- a/actor/process.go
+++ b/actor/process.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
+	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/gostackparse"
@@ -33,6 +34,7 @@ type process struct {
 	pid      *PID
 	restarts int32
 	mbuffer  []Envelope
+	mcount   int32
 }
 
 func newProcess(e *Engine, opts Opts) *process {
@@ -45,6 +47,7 @@ func newProcess(e *Engine, opts Opts) *process {
 		context: ctx,
 		mbuffer: nil,
 	}
+	ctx.getInboxCount = p.Count
 	return p
 }
 
@@ -66,6 +69,7 @@ func (p *process) Invoke(msgs []Envelope) {
 		// for bookkeeping.
 		processed = 0
 	)
+	atomic.StoreInt32(&p.mcount, int32(nmsg))
 	defer func() {
 		// If we recovered, we buffer up all the messages that we could not process
 		// so we can retry them on the next restart.
@@ -74,12 +78,14 @@ func (p *process) Invoke(msgs []Envelope) {
 			for i := 0; i < nmsg-nproc; i++ {
 				p.mbuffer[i] = msgs[i+nproc]
 			}
+			atomic.StoreInt32(&p.mcount, int32(nmsg-nproc))
 			p.tryRestart(v)
 		}
 	}()
 
 	for i := 0; i < len(msgs); i++ {
 		nproc++
+		atomic.AddInt32(&p.mcount, -1)
 		msg := msgs[i]
 		if pill, ok := msg.Msg.(poisonPill); ok {
 			// If we need to gracefuly stop, we process all the messages
@@ -207,6 +213,10 @@ func (p *process) Send(_ *PID, msg any, sender *PID) {
 }
 func (p *process) Shutdown() {
 	p.cleanup(nil)
+}
+
+func (p *process) Count() int {
+	return p.inbox.Count() + int(atomic.LoadInt32(&p.mcount))
 }
 
 func cleanTrace(stack []byte) []byte {

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -331,7 +331,7 @@ func TestGetActiveByID(t *testing.T) {
 
 	pid1 := c1.Activate("player", NewActivationConfig().WithID("1"))
 	pid2 := c2.Activate("player", NewActivationConfig().WithID("2"))
-	time.Sleep(time.Millisecond * 10)
+	time.Sleep(time.Millisecond * 200)
 
 	pid := c1.GetActiveByID("player/1")
 	assert.NotNil(t, pid)
@@ -364,7 +364,7 @@ func TestGetActiveByKind(t *testing.T) {
 	pid2 := c2.Activate("player", NewActivationConfig().WithID("2"))
 	c1.Activate("foo", NewActivationConfig().WithID("2"))
 	c1.Activate("bar", NewActivationConfig().WithID("2"))
-	time.Sleep(time.Millisecond * 10)
+	time.Sleep(time.Millisecond * 200)
 
 	pids := c1.GetActiveByKind("player")
 	assert.Len(t, pids, 2)


### PR DESCRIPTION
Fixes #196 

Also, add check to `func (p *process) cleanup(cancel context.CancelFunc)` to check for nil before using `cancel()`. Which was causing nil pointer dereference after being called by `p.cleanup(nil)` when an actor reaches it maximum number of restarts