### PR TITLE
fix: process cleanup invocations

### DIFF
--- a/actor/process.go
+++ b/actor/process.go
@@ -162,7 +162,7 @@ func (p *process) tryRestart(v any) {
 			PID:       p.pid,
 			Timestamp: time.Now(),
 		})
-		p.cleanup(nil)
+		p.cleanup(func() {})
 		return
 	}
 
@@ -206,7 +206,7 @@ func (p *process) Send(_ *PID, msg any, sender *PID) {
 	p.inbox.Send(Envelope{Msg: msg, Sender: sender})
 }
 func (p *process) Shutdown() {
-	p.cleanup(nil)
+	p.cleanup(func() {})
 }
 
 func cleanTrace(stack []byte) []byte {

--- a/actor/process_test.go
+++ b/actor/process_test.go
@@ -45,6 +45,56 @@ func Test_CleanTrace(t *testing.T) {
 	}
 }
 
+// Test_GracefulCleanup tests that process successfully finishes its lifecycles
+// after all restart attempts are exhausted. It calls cleanup function in the end.
+func Test_GracefulCleanup(t *testing.T) {
+	e, err := NewEngine(NewEngineConfig())
+	require.NoError(t, err)
+	type triggerPanic struct {
+		data int
+	}
+	stopCh := make(chan struct{})
+	pid := e.SpawnFunc(func(c *Context) {
+		fmt.Printf("Actor got message type %T\n", c.Message())
+		switch c.Message().(type) {
+		case Started:
+			c.Engine().Subscribe(c.pid)
+		case triggerPanic:
+			panicWrapper()
+		case Stopped:
+			c.Engine().Unsubscribe(c.pid)
+		}
+	}, "foo", WithMaxRestarts(0))
+
+	e.SpawnFunc(func(c *Context) {
+		fmt.Printf("Monitor got message type %T\n", c.Message())
+
+		switch c.Message().(type) {
+		case Started:
+			c.Engine().Subscribe(c.pid)
+		case ActorMaxRestartsExceededEvent:
+			m := c.Message().(ActorMaxRestartsExceededEvent)
+			// make sure PID is the same as the one we started
+			if m.PID != pid {
+				t.Errorf("expected PID %s, got %s", pid, m.PID)
+			} else {
+				stopCh <- struct{}{}
+			}
+		case Stopped:
+			c.Engine().Unsubscribe(c.pid)
+		}
+	}, "monitor", WithMaxRestarts(0))
+
+	e.Send(pid, triggerPanic{1})
+
+	select {
+	case <-stopCh:
+		fmt.Println("test passed")
+	case <-time.After(time.Second):
+		t.Error("test timed out. stack trace likely did not contain panicWrapper at the right line")
+	}
+}
+
 func panicWrapper() {
 	panic("foo")
 }


### PR DESCRIPTION

Currently any crashed actor with maxRestarts(0) leads to unrecovered panic. 
e.g. in this example -- https://github.com/anthdm/hollywood/blob/master/examples/restarts/main.go
```js
> go run cmd/test.go                                                               
foo got message type actor.Initialized
foo got message type actor.Started
foo started
foo got message type *main.message
foo got message type actor.Stopped
foo got message type actor.Stopped
panic: I failed processing this message [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1044276ec]

goroutine 36 [running]:
github.com/anthdm/hollywood/actor.(*process).cleanup(0x1400013a2c0, 0x140001440f0?)
```

the culprit for that is `nil` argument passed to `func` param in `cleanup` function.

### After the fix
no crashes, expected log message.
```js
> go run cmd/test.go
foo got message type actor.Initialized
foo got message type actor.Started
foo started
foo got message type *main.message
foo got message type actor.Stopped
foo got message type actor.Stopped
2025/04/10 22:04:12 ERROR Actor crashed too many times pid=foo/6997493373948982811
```